### PR TITLE
atomic file generation

### DIFF
--- a/run/generate_test.go
+++ b/run/generate_test.go
@@ -1,0 +1,43 @@
+package run
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+	"text/template"
+
+	"gnorm.org/gnorm/environ"
+)
+
+func TestAtomicGenerate(t *testing.T) {
+	target := OutputTarget{
+		Filename: template.Must(template.New("").Parse("{{.}}")),
+		// the contents tempalte will fail to execute becase the contents will
+		// not have a .Name field.
+		Contents: template.Must(template.New("").Parse("{{.Name}}")),
+	}
+	env := environ.Values{
+		Log: log.New(ioutil.Discard, "", 0),
+	}
+	filename := "testfile.out"
+	original := []byte("goodbye world")
+	err := ioutil.WriteFile(filename, original, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(filename)
+	contents := "hello world"
+	err = genFile(env, filename, contents, target, nil)
+	if err == nil {
+		t.Fatal("Unexpected nil error generating contents. Should have failed.")
+	}
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(b, original) {
+		t.Fatalf("Expected file to be unchanged, but was different.  Expected: %q, got: %q", original, b)
+	}
+}


### PR DESCRIPTION
This change ensures that we only overwrite files if generation succeeds.
Previously we were opening the file and truncating before doing the
generation.  Now we generate in memory and then write out to disk.  For
extra security, use an atomic writefile that ensures we won't write half
a file.

In addition, refactor the generation so the meat of the code is the same
for everything.