### PR TITLE
update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
 language: go
 
+# vanity url support
 go_import_path: gnorm.org/gnorm
 
+# In theory, older versions would probably work fine, but since this isn't a 
+# library, I'm not going to worry about older versions for now.
 go:
   - 1.9
 
+# don't call go get ./... because this hides when deps are
+# not packaged into the vendor directory.
+install: true
+
+# don't call go test -v because we want to be able to only show t.Log output when
+# a test fails
 script: go test ./...
 
+# run a test for every major OS
 env:
   - GOOS=linux
   - GOOS=windows


### PR DESCRIPTION
This changes our build so that we don't call go get ./..., which hides
if we've forgotten to vendor a dependency.