### PR TITLE
Add --format flag to preview command

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -18,8 +18,8 @@ var (
 
 func previewCmd(env environ.Values) *cobra.Command {
 	var cfgFile string
-	var useYaml bool
 	var verbose bool
+	var format string
 	preview := &cobra.Command{
 		Use:   "preview",
 		Short: "Preview the data that will be sent to your templates",
@@ -33,7 +33,7 @@ easy-to-read format.`[1:],
 			if err != nil {
 				return codeErr{err, 2}
 			}
-			if err := run.Preview(env, cfg, useYaml); err != nil {
+			if err := run.Preview(env, cfg, format); err != nil {
 				return codeErr{err, 1}
 			}
 			return nil
@@ -41,7 +41,7 @@ easy-to-read format.`[1:],
 		Args: cobra.ExactArgs(0),
 	}
 	preview.Flags().StringVarP(&cfgFile, "config", "c", "gnorm.toml", "relative path to gnorm config file")
-	preview.Flags().BoolVar(&useYaml, "yaml", false, "show output in yaml instead of tabular")
+	preview.Flags().StringVarP(&format, "format", "f", "tabular", "Specify output format e.g yaml, types or tabular")
 	preview.Flags().BoolVarP(&verbose, "verbose", "v", false, "show debugging output")
 	return preview
 }

--- a/run/preview.go
+++ b/run/preview.go
@@ -3,6 +3,7 @@ package run
 import (
 	"bytes"
 	"encoding/csv"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -116,6 +117,9 @@ func displayTypes(env environ.Values, info *data.DBData) error {
 	table := tablewriter.NewWriter(env.Stdout)
 	table.SetHeader([]string{"Original type", "Converted type"})
 	table.SetRowLine(true)
+	sort.SliceStable(cols, func(i, j int) bool {
+		return cols[i].DBType < cols[j].DBType
+	})
 	for _, v := range cols {
 		table.Append([]string{v.DBType, v.Type})
 	}

--- a/run/preview.go
+++ b/run/preview.go
@@ -51,8 +51,10 @@ func Preview(env environ.Values, cfg *Config, format string) error {
 		}
 		_, err = env.Stdout.Write(b)
 		return err
-	default:
+	case "tabular":
 		return previewTpl.Execute(env.Stdout, data)
+	default:
+		return errors.New("Unsupported format")
 	}
 }
 

--- a/run/preview_test.go
+++ b/run/preview_test.go
@@ -204,7 +204,7 @@ func TestPreviewTabular(t *testing.T) {
 	}
 
 	// tabular
-	if err := Preview(env, cfg, "false, false"); err != nil {
+	if err := Preview(env, cfg, "tabular"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -217,13 +217,13 @@ func TestPreviewTabular(t *testing.T) {
 const typesOut = `+---------------+----------------+
 | ORIGINAL TYPE | CONVERTED TYPE |
 +---------------+----------------+
-| int           | INTEGER        |
-+---------------+----------------+
 | *int          | *INTEGER       |
 +---------------+----------------+
-| string        |                |
-+---------------+----------------+
 | *string       |                |
++---------------+----------------+
+| int           | INTEGER        |
++---------------+----------------+
+| string        |                |
 +---------------+----------------+
 `
 

--- a/run/preview_test.go
+++ b/run/preview_test.go
@@ -173,7 +173,7 @@ func TestPreviewYaml(t *testing.T) {
 		Driver: dummyDriver{},
 	}
 	// with yaml
-	if err := Preview(env, cfg, true); err != nil {
+	if err := Preview(env, cfg, "yaml"); err != nil {
 		t.Fatal(err)
 	}
 	v := out.String()
@@ -204,18 +204,54 @@ func TestPreviewTabular(t *testing.T) {
 	}
 
 	// tabular
-	if err := Preview(env, cfg, false); err != nil {
+	if err := Preview(env, cfg, "false, false"); err != nil {
 		t.Fatal(err)
 	}
 
-	//without yaml
-	out.Reset()
-	errOut.Reset()
-	if err := Preview(env, cfg, false); err != nil {
-		t.Fatal(err)
-	}
 	v := out.String()
 	if v != expectTabular {
 		t.Errorf("tabular format differs from expected: %s", cmp.Diff(expectTabular, v))
+	}
+}
+
+const typesOut = `+---------------+----------------+
+| ORIGINAL TYPE | CONVERTED TYPE |
++---------------+----------------+
+| int           | INTEGER        |
++---------------+----------------+
+| *int          | *INTEGER       |
++---------------+----------------+
+| string        |                |
++---------------+----------------+
+| *string       |                |
++---------------+----------------+
+`
+
+func TestPreviewTypes(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	env := environ.Values{
+		Stdout: &out,
+		Log:    log.New(&errOut, "test: ", log.Lshortfile),
+	}
+
+	cfg := &Config{
+		NameConversion: template.Must(template.New("").Funcs(environ.FuncMap).Parse(`{{print "abc " .}}`)),
+		ConfigData: data.ConfigData{
+			NullableTypeMap: map[string]string{
+				"*int": "*INTEGER",
+			},
+			TypeMap: map[string]string{
+				"int": "INTEGER",
+			},
+		},
+		Driver: dummyDriver{},
+	}
+	if err := Preview(env, cfg, "types"); err != nil {
+		t.Fatal(err)
+	}
+	v := out.String()
+	if v != typesOut {
+		t.Errorf("expected %s got %s", typesOut, v)
 	}
 }

--- a/site/content/cli/commands/preview.md
+++ b/site/content/cli/commands/preview.md
@@ -36,9 +36,9 @@ Usage:
 
 Flags:
   -c, --config string   relative path to gnorm config file (default "gnorm.toml")
+  -f, --format string   Specify output format e.g yaml, types or tabular (default "tabular")
   -h, --help            help for preview
   -v, --verbose         show debugging output
-      --yaml            show output in yaml instead of tabular
 ```
 <!-- {{{end}}} -->
 


### PR DESCRIPTION
This simplifies flags to preview  command

e.g
```
gnorm preview --format yaml
```

This stest tabular to the default format.

Superceeds #27
Closes #11