### PR TITLE
Add support for template plugin

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -103,4 +103,9 @@ type Config struct {
 	// for different situations.  The values in this field will be available in
 	// the .Params value for all templates.
 	Params map[string]interface{}
+
+	// PluginDirs a set of absolute paths that will be added for plugin lookup.
+	// These takes precedence over the paths set in PATH environment variables.
+	// $PWD/plugins is the default and will be added automatically.
+	PluginDirs []string
 }

--- a/cli/config.go
+++ b/cli/config.go
@@ -104,8 +104,7 @@ type Config struct {
 	// the .Params value for all templates.
 	Params map[string]interface{}
 
-	// PluginDirs a set of absolute paths that will be added for plugin lookup.
-	// These takes precedence over the paths set in PATH environment variables.
-	// $PWD/plugins is the default and will be added automatically.
+	// PluginDirs a set of absolute/relative  paths that will be used for
+	// plugin lookup.
 	PluginDirs []string
 }

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -76,6 +77,18 @@ func parse(env environ.Values, r io.Reader) (*run.Config, error) {
 		return nil, err
 	}
 	cfg.Driver = d
+
+	// Add plugin lookup directories to $PATH. We add the directory named plugin
+	// found in the project root by default.
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	err = environ.AddDirsToPath(append(c.PluginDirs, filepath.Join(wd, "plugins")))
+	if err != nil {
+		return nil, err
+	}
+
 	t, err := template.New("NameConversion").Funcs(environ.FuncMap).Parse(c.NameConversion)
 	if err != nil {
 		return nil, errors.WithMessage(err, "error parsing NameConversion template")

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -78,16 +77,7 @@ func parse(env environ.Values, r io.Reader) (*run.Config, error) {
 	}
 	cfg.Driver = d
 
-	// Add plugin lookup directories to $PATH. We add the directory named plugin
-	// found in the project root by default.
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	err = environ.AddDirsToPath(append(c.PluginDirs, filepath.Join(wd, "plugins")))
-	if err != nil {
-		return nil, err
-	}
+	environ.FuncMap["plugin"] = environ.Plugin(c.PluginDirs)
 
 	t, err := template.New("NameConversion").Funcs(environ.FuncMap).Parse(c.NameConversion)
 	if err != nil {

--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -125,7 +125,7 @@ func sub(x int, vals ...int) int {
 	return x
 }
 
-// Plugin returns a function which can be used in templates for excuting plugins,
+// Plugin returns a function which can be used in templates for executing plugins,
 // dirs is the list of directories which are used fo plugin lookup.
 func Plugin(dirs []string) func(string, string, interface{}) (interface{}, error) {
 	return func(name, function string, ctx interface{}) (interface{}, error) {

--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -3,7 +3,9 @@ package environ
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/codemodus/kace"
@@ -176,4 +178,20 @@ func execJSON(runner cmdRunner, name string, data []byte, args ...string) (map[s
 		return nil, err
 	}
 	return o, nil
+}
+
+// AddDirsToPath prepends  the dirs to $PATH environment variables.
+func AddDirsToPath(dirs []string) error {
+	if dirs == nil || len(dirs) == 0 {
+		return nil
+	}
+	p := ""
+	for _, v := range append(dirs, filepath.SplitList(os.Getenv("PATH"))...) {
+		if p == "" {
+			p = v
+		} else {
+			p += string(filepath.ListSeparator) + v
+		}
+	}
+	return os.Setenv("PATH", p)
 }

--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -166,9 +166,6 @@ func execJSON(runner cmdRunner, name string, data []byte, args ...string) (map[s
 		defer stdin.Close()
 		stdin.Write(data)
 	}()
-	if err != nil {
-		return nil, err
-	}
 	v, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, errors.New(err.Error() + string(v))

--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -149,6 +149,11 @@ func simpleRunner(name string, args ...string) *exec.Cmd {
 	return exec.Command(name, args...)
 }
 
+// execJSON executes the plugin name with arguments args. It creates a io.Pipe
+// to stdin of the command and writes the data into the pipe in a separate
+// goroutine.
+//
+// The output is decoded as json data into a map[string]interface{}
 func execJSON(runner cmdRunner, name string, data []byte, args ...string) (map[string]interface{}, error) {
 	cmd := runner(name, args...)
 	stdin, err := cmd.StdinPipe()

--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -164,7 +164,7 @@ func execJSON(runner cmdRunner, name string, data []byte, args ...string) (map[s
 	}()
 	v, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, errors.New(err.Error() + string(v))
+		return nil, errors.Wrapf(err, "error running plugin %q: ", string(v))
 	}
 	o := make(map[string]interface{})
 	if err = json.Unmarshal(v, &o); err != nil {

--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -128,7 +128,7 @@ func sub(x int, vals ...int) int {
 }
 
 func plugin(name, function string, ctx interface{}) (interface{}, error) {
-	return callPlugin(simpleRunner, name, function, ctx)
+	return callPlugin(exec.Command, name, function, ctx)
 }
 
 func callPlugin(runner cmdRunner, name, function string, ctx interface{}) (interface{}, error) {
@@ -146,10 +146,6 @@ func callPlugin(runner cmdRunner, name, function string, ctx interface{}) (inter
 }
 
 type cmdRunner func(name string, args ...string) *exec.Cmd
-
-func simpleRunner(name string, args ...string) *exec.Cmd {
-	return exec.Command(name, args...)
-}
 
 // execJSON executes the plugin name with arguments args. It creates a io.Pipe
 // to stdin of the command and writes the data into the pipe in a separate

--- a/environ/funcs_test.go
+++ b/environ/funcs_test.go
@@ -1,1 +1,106 @@
 package environ
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"testing"
+	"text/template"
+)
+
+func TestPlugin(t *testing.T) {
+	table := []struct {
+		cmd, function string
+		ctx           interface{}
+		pass          bool
+		expect        map[string]interface{}
+	}{
+		{"nix", "echo", "hello,world", true,
+			map[string]interface{}{
+				"data": "hello,world",
+			},
+		},
+	}
+
+	for _, v := range table {
+		i, err := toJSON(v.ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		o, err := execJSON(testRunner, v.cmd, v.function, string(i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for k, e := range o {
+			ev := v.expect[k]
+			if !reflect.DeepEqual(e, ev) {
+				t.Errorf("expected %v got %v", ev, e)
+			}
+		}
+	}
+
+	tpl, err := template.New("plugin").Funcs(
+		template.FuncMap{
+			"plugin": func(name, function string, ctx interface{}) (interface{}, error) {
+				return callPlugin(testRunner, name, function, ctx)
+			},
+		},
+	).Parse(`{{range plugin "nix" "echoPlugin" . }}{{.}}{{end}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err = tpl.Execute(&buf, "Hello,World"); err != nil {
+		t.Fatal(err)
+	}
+	expect := "Hello,Worldnix echoPlugin"
+	got := buf.String()
+	if got != expect {
+		t.Errorf("expected %s got %s", expect, got)
+	}
+}
+
+func toJSON(ctx interface{}) ([]byte, error) {
+	d := make(map[string]interface{})
+	d["data"] = ctx
+	return json.Marshal(d)
+}
+
+func testRunner(name string, args ...string) ([]byte, error) {
+	v := []string{name}
+	return helperCMD(append(v, args...)...).CombinedOutput()
+}
+
+func helperCMD(args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--"}
+	cs = append(cs, args...)
+	return exec.Command(os.Args[0], cs...)
+}
+
+func TestHelperProcess(t *testing.T) {
+	defer os.Exit(0)
+	args := os.Args[3:]
+	switch args[0] {
+	case "nix":
+		switch args[1] {
+		case "echo":
+			fmt.Println(args[2])
+		case "echoPlugin":
+			c := args[2]
+			d := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(c), &d); err != nil {
+				t.Fatal(err)
+			}
+			data := d["data"].(string)
+			d["data"] = data + "nix echoPlugin"
+			v, err := toJSON(d)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fmt.Println(string(v))
+		}
+	}
+}

--- a/environ/funcs_test.go
+++ b/environ/funcs_test.go
@@ -1,10 +1,10 @@
 package environ
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -89,9 +89,8 @@ func TestMain(t *testing.M) {
 		args := os.Args[1:]
 		switch args[0] {
 		case "nix":
-			r := bufio.NewReader(os.Stdin)
-			c, err := r.ReadBytes('\n')
-			if err != nil && c == nil {
+			c, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
 				log.Fatal(err)
 			}
 			switch args[1] {

--- a/environ/funcs_test.go
+++ b/environ/funcs_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"text/template"
@@ -112,5 +113,21 @@ func TestMain(t *testing.M) {
 		}
 	default:
 		os.Exit(t.Run())
+	}
+}
+
+func TestAddDirsToPath(t *testing.T) {
+	p := os.Args[0]
+	dir := filepath.Dir(p)
+	err := AddDirsToPath([]string{dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	name, err := exec.LookPath(filepath.Base(p))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != p {
+		t.Errorf("expected %s got %s", p, name)
 	}
 }

--- a/environ/funcs_test.go
+++ b/environ/funcs_test.go
@@ -118,11 +118,8 @@ func TestMain(t *testing.M) {
 func TestAddDirsToPath(t *testing.T) {
 	p := os.Args[0]
 	dir := filepath.Dir(p)
-	err := AddDirsToPath([]string{dir})
-	if err != nil {
-		t.Fatal(err)
-	}
-	name, err := exec.LookPath(filepath.Base(p))
+
+	name, err := lookUpPlugin([]string{dir}, filepath.Base(p))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/site/content/templates/plugins.md
+++ b/site/content/templates/plugins.md
@@ -26,7 +26,7 @@ A plugin is a commandline executable with the following properties
   `stdin`
 - Writes the processed output to `stdout` in json format
 
-The conext send to plugins are of the shape `{ "data": SOME_VALUE}` where
+The context sent to plugins are of the shape `{ "data": SOME_VALUE}` where
 `SOME_VALUE` is any valid json object. It is up to the plugin author to decide
 how to  handle the shape and form of data.
 
@@ -42,7 +42,7 @@ lookup
 
 
 ```
-## Add this to ngorm.toml
+## Add this to gnorm.toml
 PluginDirs = ["/path/to/plugin/one" , "/path/to/plugin/two"]
 ```
 

--- a/site/content/templates/plugins.md
+++ b/site/content/templates/plugins.md
@@ -1,0 +1,59 @@
++++
+title= "Template Plugins"
+weight=3
+alwaysopen=true
++++
+
+You can call external applications as template functions. ngorm provides a
+helper function for calling external functions called `plugin`.
+
+Take for instance the following template extracted from the tests.
+
+```
+{{range plugin "nix" "echoPlugin" . }}{{.}}{{end}}
+```
+
+The snippet says call plugin `nix` and pass  `echoPlugin` as the first argument,
+we refer this argument as a function call on the plugin, and then pass the
+current context to the plugin.
+
+## What is a plugin?
+
+A plugin is a commandline executable with the following properties
+
+- Accepts a function name as the first argument.
+- Receives context in json format from `stdin` i.e it reads the context from
+  `stdin`
+- Writes the processed output to `stdout` in json format
+
+The conext send to plugins are of the shape `{ "data": SOME_VALUE}` where
+`SOME_VALUE` is any valid json object. It is up to the plugin author to decide
+how to  handle the shape and form of data.
+
+The output should be in the same format as input. The plugin can exit with non
+`0` status and anything written to `stderr` will be included in the error
+message when executing templates.
+
+
+## Configuration
+By default ngorm looks for the plugin in the following order
+
+- `$PWD/plugins`
+- System `$PATH`
+
+However there is an option to specify custom directories to look for plugins  via the configuration file.
+
+Note that, at the moment only absolute paths are supported. For example
+
+```
+## Add this to ngorm.toml
+PluginDirs = ["/path/to/plugin/one" , "/path/to/plugin/two"]
+```
+
+So, say you call plugin `foo`, gnorm will look for foo binary in the following
+order
+
+- `/path/to/plugin/one`
+- `/path/to/plugin/two`
+- `$PWD/plugins`
+- System `$PATH`

--- a/site/content/templates/plugins.md
+++ b/site/content/templates/plugins.md
@@ -36,24 +36,18 @@ message when executing templates.
 
 
 ## Configuration
-By default ngorm looks for the plugin in the following order
 
-- `$PWD/plugins`
-- System `$PATH`
+Set `PluginDirs` configuration value to the desired directories for plugin
+lookup
 
-However there is an option to specify custom directories to look for plugins  via the configuration file.
-
-Note that, at the moment only absolute paths are supported. For example
 
 ```
 ## Add this to ngorm.toml
 PluginDirs = ["/path/to/plugin/one" , "/path/to/plugin/two"]
 ```
 
-So, say you call plugin `foo`, gnorm will look for foo binary in the following
-order
+So, say you call plugin `foo`, gnorm will look for foo binary in the specified
+directories.
 
-- `/path/to/plugin/one`
-- `/path/to/plugin/two`
-- `$PWD/plugins`
-- System `$PATH`
+
+

--- a/site/content/templates/plugins.md
+++ b/site/content/templates/plugins.md
@@ -4,13 +4,13 @@ weight=3
 alwaysopen=true
 +++
 
-You can call external applications as template functions. ngorm provides a
+You can call external applications as template functions. gnorm provides a
 helper function for calling external functions called `plugin`.
 
 Take for instance the following template extracted from the tests.
 
 ```
-{{range plugin "nix" "echoPlugin" . }}{{.}}{{end}}
+{{plugin "nix" "echoPlugin" . }}
 ```
 
 The snippet says call plugin `nix` and pass  `echoPlugin` as the first argument,
@@ -47,7 +47,8 @@ PluginDirs = ["/path/to/plugin/one" , "/path/to/plugin/two"]
 ```
 
 So, say you call plugin `foo`, gnorm will look for foo binary in the specified
-directories.
+directories.The lookup is done in the same order as the directories are
+specified.
 
 
 


### PR DESCRIPTION
This is implementation of the templates functions plugins based on the discussion on the slack channel.

The  design is based on json.

A plugin is a binary/executable that accepts one argument ,  the name of the function to invoke. The context/payload is written to the `stdin` of the running plugin command in json format.

The json payload has format `{ "data" : SOME_VALUE }` where SOME_VALUE is any valid json object.

The plugin runner expect the plugin to write to `stdout`  the output after processing the payload, the format of the json output is the same as json input.

__TODO__:

- [x] send json payload in `stdin`
- [x] custom/default plugin directory
- [x] documentation