### PR TITLE
ignore site and vendor dirs for github stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+site/* linguist-documentation
+vendor/* linguist-vendored


### PR DESCRIPTION
see https://github.com/github/linguist#overrides

This should make gnorm show up as Go, not Javascript, and ignore vendor dir for number of lines changed.