### PR TITLE
Updates documentation to reference mage build instead of go run make.go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,16 +38,16 @@ git clone git@github.com:gnormal/gnorm.git
 cd gnorm 
 ```
 
-Afer this, you need to make sure that the dep tool is installed, and `$GOPATH/bin` is in your system `PATH`. Proceed to run the following commands
+After this, you need to make sure that the [dep](https://github.com/golang/dep) tool is installed, and `$GOPATH/bin` is in your system `PATH`. Once complete, proceed to run the following commands:
 
 ```shell
 dep ensure
 ```
 
-Build the binary just to be sure everything is working
+Next, make sure that [mage](https://github.com/magefile/mage) is installed. Mage will help you build the binary and ensure everything is working:
 
 ```
-go run make.go
+mage build
 ```
 
 Running `gnorm` command should give you something like this, then you are all set up and good to `go`.

--- a/cli/docs_make.go
+++ b/cli/docs_make.go
@@ -17,7 +17,7 @@ import (
 )
 
 func showDocs(env environ.Values, cmd *cobra.Command, args []string) error {
-	// this folder gets briefly copied here during go run make.go
+	// this folder gets briefly copied here during mage build
 	statikFS, err := fs.New()
 	if err != nil {
 		log.Fatal(err)

--- a/cli/docs_nomake.go
+++ b/cli/docs_nomake.go
@@ -11,7 +11,7 @@ import (
 )
 
 func showDocs(env environ.Values, cmd *cobra.Command, args []string) error {
-	fmt.Fprintln(env.Stdout, "docs not available, you need to build with go run make.go")
+	fmt.Fprintln(env.Stdout, "docs not available, you need to build with mage build")
 
 	return nil
 }

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -19,9 +19,8 @@ and all major platforms are supported.
 
 If you have a Go programming environment set up, you can `go get
 gnorm.org/gnorm`. Note that if you install this way, `gnorm version` will not
-output any build info.  If you'd like the build info to be correct, run `go run
-$GOPATH/src/gnorm.org/gnorm/make.go` which will compile the binary with the
-current git information.
+output any build info.  If you'd like the build info to be correct, run `mage build`,
+which will compile the binary with the current git information.
 
 ## Set up your config
 


### PR DESCRIPTION
Resolves #47 