### PR TITLE
Adds Primary Key Information To Tables and Columns

### DIFF
--- a/database/drivers/mysql/parse.go
+++ b/database/drivers/mysql/parse.go
@@ -108,6 +108,7 @@ func toDBColumn(c *columns.Row, log *log.Logger) (*database.Column, *database.En
 		HasDefault: c.ColumnDefault.String != "",
 		Type:       c.DataType,
 		Orig:       *c,
+		PrimaryKey: strings.Contains(c.ColumnKey, "PRI"),
 	}
 
 	// MySQL always specifies length even if it's not a part of the type. We

--- a/database/drivers/mysql/parse.go
+++ b/database/drivers/mysql/parse.go
@@ -103,12 +103,12 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 
 func toDBColumn(c *columns.Row, log *log.Logger) (*database.Column, *database.Enum, error) {
 	col := &database.Column{
-		Name:       c.ColumnName,
-		Nullable:   c.IsNullable == "YES",
-		HasDefault: c.ColumnDefault.String != "",
-		Type:       c.DataType,
-		Orig:       *c,
-		PrimaryKey: strings.Contains(c.ColumnKey, "PRI"),
+		Name:         c.ColumnName,
+		Nullable:     c.IsNullable == "YES",
+		HasDefault:   c.ColumnDefault.String != "",
+		Type:         c.DataType,
+		Orig:         *c,
+		IsPrimaryKey: strings.Contains(c.ColumnKey, "PRI"),
 	}
 
 	// MySQL always specifies length even if it's not a part of the type. We

--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -114,7 +114,7 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 			if pk.ColumnName != col.Name {
 				continue
 			}
-			col.PrimaryKey = true
+			col.IsPrimaryKey = true
 		}
 	}
 

--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -88,6 +88,36 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 		schema[c.TableName.String] = append(schema[c.TableName.String], col)
 	}
 
+	primaryKeys, err := queryPrimaryKeys(log, db, schemaNames)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("found %v primary keys", len(primaryKeys))
+	for _, pk := range primaryKeys {
+		if !filterTables(pk.SchemaName, pk.TableName) {
+			log.Printf("skipping constraint %q because it is for filtered-out table %v.%v", pk.Name, pk.SchemaName, pk.TableName)
+			continue
+		}
+
+		schema, ok := schemas[pk.SchemaName]
+		if !ok {
+			log.Printf("Should be impossible: constraint %q references unknown schema %q", pk.Name, pk.SchemaName)
+			continue
+		}
+		table, ok := schema[pk.TableName]
+		if !ok {
+			log.Printf("Should be impossible: constraint %q references unknown table %q in schema %q", pk.Name, pk.TableName, pk.SchemaName)
+			continue
+		}
+
+		for _, col := range table {
+			if pk.ColumnName != col.Name {
+				continue
+			}
+			col.PrimaryKey = true
+		}
+	}
+
 	enums, err := queryEnums(log, db, schemaNames)
 	if err != nil {
 		return nil, err
@@ -134,6 +164,40 @@ func toDBColumn(c *columns.Row, log *log.Logger) *database.Column {
 	col.Type = typ
 
 	return col
+}
+
+func queryPrimaryKeys(log *log.Logger, db *sql.DB, schemas []string) ([]*database.PrimaryKey, error) {
+	// TODO: make this work with Gnorm generated types
+	const q = `
+	SELECT k.table_schema, k.table_name, k.column_name, k.constraint_name
+	FROM information_schema.key_column_usage k
+	LEFT JOIN information_schema.table_constraints c
+    	ON k.table_schema = c.table_schema
+    	AND k.table_name = c.table_name
+    	AND k.constraint_name = c.constraint_name
+	WHERE c.constraint_type='PRIMARY KEY' AND k.table_schema IN (%s)`
+	spots := make([]string, len(schemas))
+	vals := make([]interface{}, len(schemas))
+	for x := range schemas {
+		spots[x] = fmt.Sprintf("$%v", x+1)
+		vals[x] = schemas[x]
+	}
+	query := fmt.Sprintf(q, strings.Join(spots, ", "))
+	rows, err := db.Query(query, vals...)
+	defer rows.Close()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error querying keys")
+	}
+	var ret []*database.PrimaryKey
+
+	for rows.Next() {
+		kc := &database.PrimaryKey{}
+		if err := rows.Scan(&kc.SchemaName, &kc.TableName, &kc.ColumnName, &kc.Name); err != nil {
+			return nil, errors.WithMessage(err, "error scanning key constraint")
+		}
+		ret = append(ret, kc)
+	}
+	return ret, nil
 }
 
 func queryEnums(log *log.Logger, db *sql.DB, schemas []string) (map[string][]*database.Enum, error) {

--- a/database/info.go
+++ b/database/info.go
@@ -34,7 +34,7 @@ type Table struct {
 	Columns []*Column // ordered list of columns in this table
 }
 
-// IsPrimaryKey contains the definition of a database primary key.
+// PrimaryKey contains the definition of a database primary key.
 type PrimaryKey struct {
 	SchemaName string // the original name of the schema in the db
 	TableName  string // the original name of the table in the db

--- a/database/info.go
+++ b/database/info.go
@@ -34,7 +34,7 @@ type Table struct {
 	Columns []*Column // ordered list of columns in this table
 }
 
-// PrimaryKey contains the definition of a database primary key.
+// IsPrimaryKey contains the definition of a database primary key.
 type PrimaryKey struct {
 	SchemaName string // the original name of the schema in the db
 	TableName  string // the original name of the table in the db
@@ -44,15 +44,15 @@ type PrimaryKey struct {
 
 // Column contains data about a column in a table.
 type Column struct {
-	Name        string      // the original name of the column in the DB
-	Type        string      // the original type of the column in the DB
-	IsArray     bool        // true if the column type is an array
-	Length      int         // non-zero if the type has a length (e.g. varchar[16])
-	UserDefined bool        // true if the type is user-defined
-	Nullable    bool        // true if the column is not NON NULL
-	HasDefault  bool        // true if the column has a default
-	PrimaryKey  bool        // true if the column is a primary key
-	Orig        interface{} // the raw database column data
+	Name         string      // the original name of the column in the DB
+	Type         string      // the original type of the column in the DB
+	IsArray      bool        // true if the column type is an array
+	Length       int         // non-zero if the type has a length (e.g. varchar[16])
+	UserDefined  bool        // true if the type is user-defined
+	Nullable     bool        // true if the column is not NON NULL
+	HasDefault   bool        // true if the column has a default
+	IsPrimaryKey bool        // true if the column is a primary key
+	Orig         interface{} // the raw database column data
 }
 
 // Driver defines the base interface for databases that are supported by gnorm

--- a/database/info.go
+++ b/database/info.go
@@ -28,10 +28,18 @@ type EnumValue struct {
 	Value int    // the value for this enum value (order)
 }
 
-// Table contains the definiiton of a database table.
+// Table contains the definition of a database table.
 type Table struct {
 	Name    string    // the original name of the table in the DB
 	Columns []*Column // ordered list of columns in this table
+}
+
+// PrimaryKey contains the definition of a database primary key.
+type PrimaryKey struct {
+	SchemaName string // the original name of the schema in the db
+	TableName  string // the original name of the table in the db
+	ColumnName string // the original name of the column in the db
+	Name       string // the original name of the key constraint in the db
 }
 
 // Column contains data about a column in a table.
@@ -43,6 +51,7 @@ type Column struct {
 	UserDefined bool        // true if the type is user-defined
 	Nullable    bool        // true if the column is not NON NULL
 	HasDefault  bool        // true if the column has a default
+	PrimaryKey  bool        // true if the column is a primary key
 	Orig        interface{} // the raw database column data
 }
 

--- a/run/convert.go
+++ b/run/convert.go
@@ -71,15 +71,15 @@ func makeData(log *log.Logger, info *database.Info, cfg *Config) (*data.DBData, 
 			}
 			for _, c := range t.Columns {
 				col := &data.Column{
-					DBName:      c.Name,
-					DBType:      c.Type,
-					IsArray:     c.IsArray,
-					Length:      c.Length,
-					UserDefined: c.UserDefined,
-					Nullable:    c.Nullable,
-					HasDefault:  c.HasDefault,
-					PrimaryKey:  c.PrimaryKey,
-					Orig:        c.Orig,
+					DBName:       c.Name,
+					DBType:       c.Type,
+					IsArray:      c.IsArray,
+					Length:       c.Length,
+					UserDefined:  c.UserDefined,
+					Nullable:     c.Nullable,
+					HasDefault:   c.HasDefault,
+					IsPrimaryKey: c.IsPrimaryKey,
+					Orig:         c.Orig,
 				}
 				table.Columns = append(table.Columns, col)
 				table.ColumnsByName[col.DBName] = col
@@ -109,7 +109,7 @@ func makeData(log *log.Logger, info *database.Info, cfg *Config) (*data.DBData, 
 func filterPrimaryKeyColumns(columns []*data.Column) []*data.Column {
 	var pkColumns []*data.Column
 	for _, column := range columns {
-		if column.PrimaryKey {
+		if column.IsPrimaryKey {
 			pkColumns = append(pkColumns, column)
 		}
 	}

--- a/run/convert.go
+++ b/run/convert.go
@@ -78,6 +78,7 @@ func makeData(log *log.Logger, info *database.Info, cfg *Config) (*data.DBData, 
 					UserDefined: c.UserDefined,
 					Nullable:    c.Nullable,
 					HasDefault:  c.HasDefault,
+					PrimaryKey:  c.PrimaryKey,
 					Orig:        c.Orig,
 				}
 				table.Columns = append(table.Columns, col)
@@ -99,7 +100,19 @@ func makeData(log *log.Logger, info *database.Info, cfg *Config) (*data.DBData, 
 					}
 				}
 			}
+			table.PrimaryKeys = filterPrimaryKeyColumns(table.Columns)
 		}
 	}
 	return db, nil
+}
+
+func filterPrimaryKeyColumns(columns []*data.Column) []*data.Column {
+	var pkColumns []*data.Column
+	for _, column := range columns {
+		if column.PrimaryKey {
+			pkColumns = append(pkColumns, column)
+		}
+	}
+
+	return pkColumns
 }

--- a/run/data/data.go
+++ b/run/data/data.go
@@ -53,6 +53,7 @@ type Table struct {
 	Schema        *Schema            `yaml:"-" json:"-"` // the schema this table is in
 	Columns       Columns            // Database columns
 	ColumnsByName map[string]*Column `yaml:"-" json:"-"` // dbname to column
+	PrimaryKeys   Columns            // Primary Key Columns
 }
 
 // Column is the data about a DB column of a table.
@@ -66,6 +67,7 @@ type Column struct {
 	UserDefined bool        // true if the type is user-defined
 	Nullable    bool        // true if the column is not NON NULL
 	HasDefault  bool        // true if the column has a default
+	PrimaryKey  bool        // true if the column is a primary key
 	Orig        interface{} `yaml:"-" json:"-"` // the raw database column data
 }
 

--- a/run/data/data.go
+++ b/run/data/data.go
@@ -56,19 +56,24 @@ type Table struct {
 	PrimaryKeys   Columns            // Primary Key Columns
 }
 
+// Returns true if Table has one or more primary keys
+func (t *Table) HasPrimaryKey() bool {
+	return len(t.PrimaryKeys) > 0
+}
+
 // Column is the data about a DB column of a table.
 type Column struct {
-	Name        string      // the converted name of the column
-	DBName      string      // the original name of the column in the DB
-	Type        string      // the converted name of the type
-	DBType      string      // the original type of the column in the DB
-	IsArray     bool        // true if the column type is an array
-	Length      int         // non-zero if the type has a length (e.g. varchar[16])
-	UserDefined bool        // true if the type is user-defined
-	Nullable    bool        // true if the column is not NON NULL
-	HasDefault  bool        // true if the column has a default
-	PrimaryKey  bool        // true if the column is a primary key
-	Orig        interface{} `yaml:"-" json:"-"` // the raw database column data
+	Name         string      // the converted name of the column
+	DBName       string      // the original name of the column in the DB
+	Type         string      // the converted name of the type
+	DBType       string      // the original type of the column in the DB
+	IsArray      bool        // true if the column type is an array
+	Length       int         // non-zero if the type has a length (e.g. varchar[16])
+	UserDefined  bool        // true if the type is user-defined
+	Nullable     bool        // true if the column is not NON NULL
+	HasDefault   bool        // true if the column has a default
+	IsPrimaryKey bool        // true if the column is a primary key
+	Orig         interface{} `yaml:"-" json:"-"` // the raw database column data
 }
 
 // Enum represents a type that has a set of allowed values.

--- a/run/preview.go
+++ b/run/preview.go
@@ -28,7 +28,7 @@ Enum: {{.Name}}({{$schema}}.{{.DBName}})
 {{end -}}
 {{range .Tables}}
 Table: {{.Name}}({{$schema}}.{{.DBName}})
-{{makeTable .Columns "{{.Name}}|{{.DBName}}|{{.Type}}|{{.DBType}}|{{.IsArray}}|{{.Length}}|{{.UserDefined}}|{{.Nullable}}|{{.HasDefault}}" "Name" "DBName" "Type" "DBType" "IsArray" "Length" "UserDefined" "Nullable" "HasDefault"}}
+{{makeTable .Columns "{{.Name}}|{{.DBName}}|{{.Type}}|{{.DBType}}|{{.IsArray}}|{{.PrimaryKey}}|{{.Length}}|{{.UserDefined}}|{{.Nullable}}|{{.HasDefault}}" "Name" "DBName" "Type" "DBType" "IsArray" "PrimaryKey" "Length" "UserDefined" "Nullable" "HasDefault"}}
 {{end -}}
 {{end -}}
 `))

--- a/run/preview.go
+++ b/run/preview.go
@@ -28,7 +28,7 @@ Enum: {{.Name}}({{$schema}}.{{.DBName}})
 {{end -}}
 {{range .Tables}}
 Table: {{.Name}}({{$schema}}.{{.DBName}})
-{{makeTable .Columns "{{.Name}}|{{.DBName}}|{{.Type}}|{{.DBType}}|{{.IsArray}}|{{.PrimaryKey}}|{{.Length}}|{{.UserDefined}}|{{.Nullable}}|{{.HasDefault}}" "Name" "DBName" "Type" "DBType" "IsArray" "PrimaryKey" "Length" "UserDefined" "Nullable" "HasDefault"}}
+{{makeTable .Columns "{{.Name}}|{{.DBName}}|{{.Type}}|{{.DBType}}|{{.IsArray}}|{{.IsPrimaryKey}}|{{.Length}}|{{.UserDefined}}|{{.Nullable}}|{{.HasDefault}}" "Name" "DBName" "Type" "DBType" "IsArray" "IsPrimaryKey" "Length" "UserDefined" "Nullable" "HasDefault"}}
 {{end -}}
 {{end -}}
 `))

--- a/run/preview_test.go
+++ b/run/preview_test.go
@@ -53,8 +53,9 @@ func (dummyDriver) Parse(log *log.Logger, conn string, schemaNames []string, fil
 			Tables: []*database.Table{{
 				Name: "table",
 				Columns: []*database.Column{{
-					Name: "col1",
-					Type: "int",
+					Name:       "col1",
+					Type:       "int",
+					PrimaryKey: true,
 				}, {
 					Name:     "col2",
 					Type:     "*int",
@@ -94,6 +95,7 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: false
       hasdefault: false
+      primarykey: true
     - name: abc col2
       dbname: col2
       type: '*INTEGER'
@@ -103,6 +105,7 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: true
       hasdefault: false
+      primarykey: false
     - name: abc col3
       dbname: col3
       type: ""
@@ -112,6 +115,7 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: false
       hasdefault: false
+      primarykey: false
     - name: abc col4
       dbname: col4
       type: ""
@@ -121,6 +125,18 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: true
       hasdefault: false
+      primarykey: false
+    primarykeys:
+    - name: abc col1
+      dbname: col1
+      type: INTEGER
+      dbtype: int
+      isarray: false
+      length: 0
+      userdefined: false
+      nullable: false
+      hasdefault: false
+      primarykey: true
   enums:
   - name: abc enum
     dbname: enum
@@ -141,14 +157,14 @@ Enum: abc enum(schema.enum)
 
 
 Table: abc table(schema.table)
-+----------+--------+----------+---------+---------+--------+-------------+----------+------------+
-|   Name   | DBName |   Type   | DBType  | IsArray | Length | UserDefined | Nullable | HasDefault |
-+----------+--------+----------+---------+---------+--------+-------------+----------+------------+
-| abc col1 | col1   | INTEGER  | int     | false   |      0 | false       | false    | false      |
-| abc col2 | col2   | *INTEGER | *int    | false   |      0 | false       | true     | false      |
-| abc col3 | col3   |          | string  | false   |      0 | false       | false    | false      |
-| abc col4 | col4   |          | *string | false   |      0 | false       | true     | false      |
-+----------+--------+----------+---------+---------+--------+-------------+----------+------------+
++----------+--------+----------+---------+---------+------------+--------+-------------+----------+------------+
+|   Name   | DBName |   Type   | DBType  | IsArray | PrimaryKey | Length | UserDefined | Nullable | HasDefault |
++----------+--------+----------+---------+---------+------------+--------+-------------+----------+------------+
+| abc col1 | col1   | INTEGER  | int     | false   | true       |      0 | false       | false    | false      |
+| abc col2 | col2   | *INTEGER | *int    | false   | false      |      0 | false       | true     | false      |
+| abc col3 | col3   |          | string  | false   | false      |      0 | false       | false    | false      |
+| abc col4 | col4   |          | *string | false   | false      |      0 | false       | true     | false      |
++----------+--------+----------+---------+---------+------------+--------+-------------+----------+------------+
 
 `
 
@@ -202,7 +218,8 @@ var expectJSON = `
               "Length": 0,
               "UserDefined": false,
               "Nullable": false,
-              "HasDefault": false
+              "HasDefault": false,
+              "PrimaryKey": true
             },
             {
               "Name": "abc col2",
@@ -213,7 +230,8 @@ var expectJSON = `
               "Length": 0,
               "UserDefined": false,
               "Nullable": true,
-              "HasDefault": false
+              "HasDefault": false,
+              "PrimaryKey": false
             },
             {
               "Name": "abc col3",
@@ -224,7 +242,8 @@ var expectJSON = `
               "Length": 0,
               "UserDefined": false,
               "Nullable": false,
-              "HasDefault": false
+              "HasDefault": false,
+              "PrimaryKey": false
             },
             {
               "Name": "abc col4",
@@ -235,7 +254,22 @@ var expectJSON = `
               "Length": 0,
               "UserDefined": false,
               "Nullable": true,
-              "HasDefault": false
+              "HasDefault": false,
+              "PrimaryKey": false
+            }
+          ],
+          "PrimaryKeys": [
+            {
+              "Name": "abc col1",
+              "DBName": "col1",
+              "Type": "INTEGER",
+              "DBType": "int",
+              "IsArray": false,
+              "Length": 0,
+              "UserDefined": false,
+              "Nullable": false,
+              "HasDefault": false,
+              "PrimaryKey": true
             }
           ]
         }

--- a/run/preview_test.go
+++ b/run/preview_test.go
@@ -53,9 +53,9 @@ func (dummyDriver) Parse(log *log.Logger, conn string, schemaNames []string, fil
 			Tables: []*database.Table{{
 				Name: "table",
 				Columns: []*database.Column{{
-					Name:       "col1",
-					Type:       "int",
-					PrimaryKey: true,
+					Name:         "col1",
+					Type:         "int",
+					IsPrimaryKey: true,
 				}, {
 					Name:     "col2",
 					Type:     "*int",
@@ -95,7 +95,7 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: false
       hasdefault: false
-      primarykey: true
+      isprimarykey: true
     - name: abc col2
       dbname: col2
       type: '*INTEGER'
@@ -105,7 +105,7 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: true
       hasdefault: false
-      primarykey: false
+      isprimarykey: false
     - name: abc col3
       dbname: col3
       type: ""
@@ -115,7 +115,7 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: false
       hasdefault: false
-      primarykey: false
+      isprimarykey: false
     - name: abc col4
       dbname: col4
       type: ""
@@ -125,7 +125,7 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: true
       hasdefault: false
-      primarykey: false
+      isprimarykey: false
     primarykeys:
     - name: abc col1
       dbname: col1
@@ -136,7 +136,7 @@ const expectYaml = `schemas:
       userdefined: false
       nullable: false
       hasdefault: false
-      primarykey: true
+      isprimarykey: true
   enums:
   - name: abc enum
     dbname: enum
@@ -157,14 +157,14 @@ Enum: abc enum(schema.enum)
 
 
 Table: abc table(schema.table)
-+----------+--------+----------+---------+---------+------------+--------+-------------+----------+------------+
-|   Name   | DBName |   Type   | DBType  | IsArray | PrimaryKey | Length | UserDefined | Nullable | HasDefault |
-+----------+--------+----------+---------+---------+------------+--------+-------------+----------+------------+
-| abc col1 | col1   | INTEGER  | int     | false   | true       |      0 | false       | false    | false      |
-| abc col2 | col2   | *INTEGER | *int    | false   | false      |      0 | false       | true     | false      |
-| abc col3 | col3   |          | string  | false   | false      |      0 | false       | false    | false      |
-| abc col4 | col4   |          | *string | false   | false      |      0 | false       | true     | false      |
-+----------+--------+----------+---------+---------+------------+--------+-------------+----------+------------+
++----------+--------+----------+---------+---------+--------------+--------+-------------+----------+------------+
+|   Name   | DBName |   Type   | DBType  | IsArray | IsPrimaryKey | Length | UserDefined | Nullable | HasDefault |
++----------+--------+----------+---------+---------+--------------+--------+-------------+----------+------------+
+| abc col1 | col1   | INTEGER  | int     | false   | true         |      0 | false       | false    | false      |
+| abc col2 | col2   | *INTEGER | *int    | false   | false        |      0 | false       | true     | false      |
+| abc col3 | col3   |          | string  | false   | false        |      0 | false       | false    | false      |
+| abc col4 | col4   |          | *string | false   | false        |      0 | false       | true     | false      |
++----------+--------+----------+---------+---------+--------------+--------+-------------+----------+------------+
 
 `
 
@@ -219,7 +219,7 @@ var expectJSON = `
               "UserDefined": false,
               "Nullable": false,
               "HasDefault": false,
-              "PrimaryKey": true
+              "IsPrimaryKey": true
             },
             {
               "Name": "abc col2",
@@ -231,7 +231,7 @@ var expectJSON = `
               "UserDefined": false,
               "Nullable": true,
               "HasDefault": false,
-              "PrimaryKey": false
+              "IsPrimaryKey": false
             },
             {
               "Name": "abc col3",
@@ -243,7 +243,7 @@ var expectJSON = `
               "UserDefined": false,
               "Nullable": false,
               "HasDefault": false,
-              "PrimaryKey": false
+              "IsPrimaryKey": false
             },
             {
               "Name": "abc col4",
@@ -255,7 +255,7 @@ var expectJSON = `
               "UserDefined": false,
               "Nullable": true,
               "HasDefault": false,
-              "PrimaryKey": false
+              "IsPrimaryKey": false
             }
           ],
           "PrimaryKeys": [
@@ -269,7 +269,7 @@ var expectJSON = `
               "UserDefined": false,
               "Nullable": false,
               "HasDefault": false,
-              "PrimaryKey": true
+              "IsPrimaryKey": true
             }
           ]
         }

--- a/site/content/templates/data.md
+++ b/site/content/templates/data.md
@@ -72,6 +72,7 @@ Column is the data about a DB column of a table.
 | UserDefined | boolean | true if the type is user-defined
 | Nullable | boolean | true if the column is not NON NULL
 | HasDefault | boolean | true if the column has a default
+| PrimaryKey | boolean | true if the column is a primary key
 | Orig | db-specific | the raw database column data (different per db type)
 
 
@@ -157,6 +158,7 @@ Strings is a list of string values with the following methods
 | Schema | [Schema](#schema)  | the schema this table is in
 | Columns | [Columns](#columns) | ordered list of Database columns
 | ColumnsByName | map[string][Column](#column) | map of column dbname to column
+| PrimaryKeys | [Columns](#columns) | primary key columns
 
 ### Tables
 

--- a/site/content/templates/data.md
+++ b/site/content/templates/data.md
@@ -72,7 +72,7 @@ Column is the data about a DB column of a table.
 | UserDefined | boolean | true if the type is user-defined
 | Nullable | boolean | true if the column is not NON NULL
 | HasDefault | boolean | true if the column has a default
-| PrimaryKey | boolean | true if the column is a primary key
+| IsPrimaryKey | boolean | true if the column is a primary key
 | Orig | db-specific | the raw database column data (different per db type)
 
 
@@ -85,7 +85,7 @@ have the following properties:
 | Property | Type | Description |
 | --- | ---- | --- |
 | DBNames | [Strings](#strings) | the ordered list of DBNames of all the columns 
-| Names | [Strings](#stings) | the ordered list of Names of all the columns
+| Names | [Strings](#strings) | the ordered list of Names of all the columns
 
 ### ConfigData
 
@@ -119,7 +119,7 @@ have the following properties:
 | Property | Type | Description |
 | --- | ---- | --- |
 | DBNames | [Strings](#strings) | the ordered list of DBNames of all the enums 
-| Names | [Strings](#stings) | the ordered list of Names of all the enums
+| Names | [Strings](#strings) | the ordered list of Names of all the enums
 
 ### EnumValue
 
@@ -159,6 +159,7 @@ Strings is a list of string values with the following methods
 | Columns | [Columns](#columns) | ordered list of Database columns
 | ColumnsByName | map[string][Column](#column) | map of column dbname to column
 | PrimaryKeys | [Columns](#columns) | primary key columns
+| HasPrimaryKey | bool | does the column have at least one primary key
 
 ### Tables
 
@@ -168,4 +169,4 @@ have the following properties:
 | Property | Type | Description |
 | --- | ---- | --- |
 | DBNames | [Strings](#strings) | the list of DBNames of all the tables
-| Names | [Strings](#stings) | the list of Names of all the tables
+| Names | [Strings](#strings) | the list of Names of all the tables


### PR DESCRIPTION
PrimaryKeys are stored in the data.Table as a slice of columns. PrimaryKey is stored in the data.Column as a bool. This allows for easy iteration in template building of all primary key columns of a table.

For Postgres, a new query has been written as queryPrimaryKeys to get the required information. With the required Joins, this could not be done using Gnorm generated types at this time.

For Mysql, the primary key data was already available through the COLUMN_KEY field.