### PR TITLE
Convert []interface{} to []string from plugins

### DIFF
--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -17,49 +17,50 @@ import (
 // FuncMap is the default list of functions available to templates.  If you add
 // methods here, please keep them alphabetical.
 var FuncMap = map[string]interface{}{
-	"camel":        kace.Camel,
-	"compare":      strings.Compare,
-	"contains":     strings.Contains,
-	"containsAny":  strings.ContainsAny,
-	"count":        strings.Count,
-	"dec":          dec,
-	"equalFold":    strings.EqualFold,
-	"fields":       strings.Fields,
-	"hasPrefix":    strings.HasPrefix,
-	"hasSuffix":    strings.HasPrefix,
-	"inc":          inc,
-	"index":        strings.Index,
-	"indexAny":     strings.IndexAny,
-	"join":         strings.Join,
-	"kebab":        kace.Kebab,
-	"kebabUpper":   kace.KebabUpper,
-	"lastIndex":    strings.LastIndex,
-	"lastIndexAny": strings.LastIndexAny,
-	"makeMap":      makeMap,
-	"makeSlice":    makeSlice,
-	"numbers":      numbers,
-	"pascal":       kace.Pascal,
-	"repeat":       strings.Repeat,
-	"replace":      strings.Replace,
-	"sliceString":  sliceString,
-	"snake":        kace.Snake,
-	"snakeUpper":   kace.SnakeUpper,
-	"split":        strings.Split,
-	"splitAfter":   strings.SplitAfter,
-	"splitAfterN":  strings.SplitAfterN,
-	"splitN":       strings.SplitN,
-	"sub":          sub,
-	"sum":          sum,
-	"title":        strings.Title,
-	"toLower":      strings.ToLower,
-	"toTitle":      strings.ToTitle,
-	"toUpper":      strings.ToUpper,
-	"trim":         strings.Trim,
-	"trimLeft":     strings.TrimLeft,
-	"trimPrefix":   strings.TrimPrefix,
-	"trimRight":    strings.TrimRight,
-	"trimSpace":    strings.TrimSpace,
-	"trimSuffix":   strings.TrimSuffix,
+	"camel":           kace.Camel,
+	"compare":         strings.Compare,
+	"contains":        strings.Contains,
+	"containsAny":     strings.ContainsAny,
+	"count":           strings.Count,
+	"dec":             dec,
+	"equalFold":       strings.EqualFold,
+	"fields":          strings.Fields,
+	"hasPrefix":       strings.HasPrefix,
+	"hasSuffix":       strings.HasPrefix,
+	"inc":             inc,
+	"index":           strings.Index,
+	"indexAny":        strings.IndexAny,
+	"join":            strings.Join,
+	"kebab":           kace.Kebab,
+	"kebabUpper":      kace.KebabUpper,
+	"lastIndex":       strings.LastIndex,
+	"lastIndexAny":    strings.LastIndexAny,
+	"makeMap":         makeMap,
+	"makeSlice":       makeSlice,
+	"makeStringSlice": makeStringSlice,
+	"numbers":         numbers,
+	"pascal":          kace.Pascal,
+	"repeat":          strings.Repeat,
+	"replace":         strings.Replace,
+	"sliceString":     sliceString,
+	"snake":           kace.Snake,
+	"snakeUpper":      kace.SnakeUpper,
+	"split":           strings.Split,
+	"splitAfter":      strings.SplitAfter,
+	"splitAfterN":     strings.SplitAfterN,
+	"splitN":          strings.SplitN,
+	"sub":             sub,
+	"sum":             sum,
+	"title":           strings.Title,
+	"toLower":         strings.ToLower,
+	"toTitle":         strings.ToTitle,
+	"toUpper":         strings.ToUpper,
+	"trim":            strings.Trim,
+	"trimLeft":        strings.TrimLeft,
+	"trimPrefix":      strings.TrimPrefix,
+	"trimRight":       strings.TrimRight,
+	"trimSpace":       strings.TrimSpace,
+	"trimSuffix":      strings.TrimSuffix,
 }
 
 // sliceString returns a slice of s from index start to end.
@@ -81,6 +82,18 @@ func makeSlice(vals ...interface{}) interface{} {
 		}
 	}
 	return ss
+}
+
+func makeStringSlice(in []interface{}) ([]string, error) {
+	var out []string
+	for _, i := range in {
+		s, ok := i.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected input to be string, but got %T", i)
+		}
+		out = append(out, s)
+	}
+	return out, nil
 }
 
 // makeMap expects an even number of parameters, in order to have name:value

--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -17,50 +17,49 @@ import (
 // FuncMap is the default list of functions available to templates.  If you add
 // methods here, please keep them alphabetical.
 var FuncMap = map[string]interface{}{
-	"camel":           kace.Camel,
-	"compare":         strings.Compare,
-	"contains":        strings.Contains,
-	"containsAny":     strings.ContainsAny,
-	"count":           strings.Count,
-	"dec":             dec,
-	"equalFold":       strings.EqualFold,
-	"fields":          strings.Fields,
-	"hasPrefix":       strings.HasPrefix,
-	"hasSuffix":       strings.HasPrefix,
-	"inc":             inc,
-	"index":           strings.Index,
-	"indexAny":        strings.IndexAny,
-	"join":            strings.Join,
-	"kebab":           kace.Kebab,
-	"kebabUpper":      kace.KebabUpper,
-	"lastIndex":       strings.LastIndex,
-	"lastIndexAny":    strings.LastIndexAny,
-	"makeMap":         makeMap,
-	"makeSlice":       makeSlice,
-	"makeStringSlice": makeStringSlice,
-	"numbers":         numbers,
-	"pascal":          kace.Pascal,
-	"repeat":          strings.Repeat,
-	"replace":         strings.Replace,
-	"sliceString":     sliceString,
-	"snake":           kace.Snake,
-	"snakeUpper":      kace.SnakeUpper,
-	"split":           strings.Split,
-	"splitAfter":      strings.SplitAfter,
-	"splitAfterN":     strings.SplitAfterN,
-	"splitN":          strings.SplitN,
-	"sub":             sub,
-	"sum":             sum,
-	"title":           strings.Title,
-	"toLower":         strings.ToLower,
-	"toTitle":         strings.ToTitle,
-	"toUpper":         strings.ToUpper,
-	"trim":            strings.Trim,
-	"trimLeft":        strings.TrimLeft,
-	"trimPrefix":      strings.TrimPrefix,
-	"trimRight":       strings.TrimRight,
-	"trimSpace":       strings.TrimSpace,
-	"trimSuffix":      strings.TrimSuffix,
+	"camel":        kace.Camel,
+	"compare":      strings.Compare,
+	"contains":     strings.Contains,
+	"containsAny":  strings.ContainsAny,
+	"count":        strings.Count,
+	"dec":          dec,
+	"equalFold":    strings.EqualFold,
+	"fields":       strings.Fields,
+	"hasPrefix":    strings.HasPrefix,
+	"hasSuffix":    strings.HasPrefix,
+	"inc":          inc,
+	"index":        strings.Index,
+	"indexAny":     strings.IndexAny,
+	"join":         strings.Join,
+	"kebab":        kace.Kebab,
+	"kebabUpper":   kace.KebabUpper,
+	"lastIndex":    strings.LastIndex,
+	"lastIndexAny": strings.LastIndexAny,
+	"makeMap":      makeMap,
+	"makeSlice":    makeSlice,
+	"numbers":      numbers,
+	"pascal":       kace.Pascal,
+	"repeat":       strings.Repeat,
+	"replace":      strings.Replace,
+	"sliceString":  sliceString,
+	"snake":        kace.Snake,
+	"snakeUpper":   kace.SnakeUpper,
+	"split":        strings.Split,
+	"splitAfter":   strings.SplitAfter,
+	"splitAfterN":  strings.SplitAfterN,
+	"splitN":       strings.SplitN,
+	"sub":          sub,
+	"sum":          sum,
+	"title":        strings.Title,
+	"toLower":      strings.ToLower,
+	"toTitle":      strings.ToTitle,
+	"toUpper":      strings.ToUpper,
+	"trim":         strings.Trim,
+	"trimLeft":     strings.TrimLeft,
+	"trimPrefix":   strings.TrimPrefix,
+	"trimRight":    strings.TrimRight,
+	"trimSpace":    strings.TrimSpace,
+	"trimSuffix":   strings.TrimSuffix,
 }
 
 // sliceString returns a slice of s from index start to end.
@@ -82,18 +81,6 @@ func makeSlice(vals ...interface{}) interface{} {
 		}
 	}
 	return ss
-}
-
-func makeStringSlice(in []interface{}) ([]string, error) {
-	var out []string
-	for _, i := range in {
-		s, ok := i.(string)
-		if !ok {
-			return nil, fmt.Errorf("expected input to be string, but got %T", i)
-		}
-		out = append(out, s)
-	}
-	return out, nil
 }
 
 // makeMap expects an even number of parameters, in order to have name:value
@@ -173,6 +160,27 @@ func lookUpPlugin(dirs []string, name string) (p string, err error) {
 	return
 }
 
+func convert(v interface{}) interface{} {
+	if m, ok := v.(map[string]interface{}); ok {
+		for k, v := range m {
+			m[k] = convert(v)
+		}
+	}
+	list, ok := v.([]interface{})
+	if !ok {
+		return v
+	}
+	var str []string
+	for _, val := range list {
+		s, ok := val.(string)
+		if !ok {
+			return v
+		}
+		str = append(str, s)
+	}
+	return str
+}
+
 func callPlugin(runner cmdRunner, name, function string, ctx interface{}) (interface{}, error) {
 	d := make(map[string]interface{})
 	d["data"] = ctx
@@ -184,7 +192,8 @@ func callPlugin(runner cmdRunner, name, function string, ctx interface{}) (inter
 	if err != nil {
 		return nil, err
 	}
-	return o["data"], nil
+
+	return convert(o["data"]), nil
 }
 
 type cmdRunner func(name string, args ...string) *exec.Cmd

--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -165,16 +165,23 @@ func convert(v interface{}) interface{} {
 		for k, v := range m {
 			m[k] = convert(v)
 		}
+		return m
 	}
+
 	list, ok := v.([]interface{})
 	if !ok {
 		return v
 	}
+
 	var str []string
 	for _, val := range list {
 		s, ok := val.(string)
 		if !ok {
-			return v
+			var out []interface{}
+			for _, x := range list {
+				out = append(out, convert(x))
+			}
+			return out
 		}
 		str = append(str, s)
 	}

--- a/environ/funcs_test.go
+++ b/environ/funcs_test.go
@@ -14,6 +14,34 @@ import (
 	"text/template"
 )
 
+func TestMakeStringSlice(t *testing.T) {
+	t.Run("ideal input", func(t *testing.T) {
+		expected := []string{"things", "and", "stuff"}
+		exampleInput := []interface{}{"things", "and", "stuff"}
+
+		actual, err := makeStringSlice(exampleInput)
+
+		if err != nil {
+			t.Errorf("error returned from makeStringSlice with what should be valid input")
+		}
+
+		for ix, s := range actual {
+			if expected[ix] != s {
+				t.Errorf("expected %s got %s", s, expected[ix])
+			}
+		}
+	})
+
+	t.Run("invalid input", func(t *testing.T) {
+		exampleInput := []interface{}{1, "two", fmt.Println}
+		_, err := makeStringSlice(exampleInput)
+
+		if err == nil {
+			t.Errorf("error not returned from makeStringSlice with what should be invalid input")
+		}
+	})
+}
+
 func TestPlugin(t *testing.T) {
 	table := []struct {
 		cmd, function string

--- a/environ/funcs_test.go
+++ b/environ/funcs_test.go
@@ -14,34 +14,6 @@ import (
 	"text/template"
 )
 
-func TestMakeStringSlice(t *testing.T) {
-	t.Run("ideal input", func(t *testing.T) {
-		expected := []string{"things", "and", "stuff"}
-		exampleInput := []interface{}{"things", "and", "stuff"}
-
-		actual, err := makeStringSlice(exampleInput)
-
-		if err != nil {
-			t.Errorf("error returned from makeStringSlice with what should be valid input")
-		}
-
-		for ix, s := range actual {
-			if expected[ix] != s {
-				t.Errorf("expected %s got %s", s, expected[ix])
-			}
-		}
-	})
-
-	t.Run("invalid input", func(t *testing.T) {
-		exampleInput := []interface{}{1, "two", fmt.Println}
-		_, err := makeStringSlice(exampleInput)
-
-		if err == nil {
-			t.Errorf("error not returned from makeStringSlice with what should be invalid input")
-		}
-	})
-}
-
 func TestPlugin(t *testing.T) {
 	table := []struct {
 		cmd, function string
@@ -109,6 +81,34 @@ func helperCMD(args ...string) *exec.Cmd {
 	cmd := exec.Command(os.Args[0], args...)
 	cmd.Env = []string{"GO_TEST_ENV=command"}
 	return cmd
+}
+
+func TestConvert(t *testing.T) {
+	t.Run("ordinary use case", func(t *testing.T) {
+		expected := []interface{}{"things", "and", "stuff"}
+
+		actual, ok := convert(expected).([]string)
+		if !ok {
+			t.Error("convert returned an interface that couldn't be converted to []string")
+		}
+
+		for i, s := range expected {
+			if actual[i] != s {
+				t.Errorf("expected %s got %s", s, actual[i])
+			}
+		}
+	})
+
+	t.Run("early exit", func(t *testing.T) {
+		expected := []interface{}{"things", nil, "stuff"}
+		actual := convert(expected).([]interface{})
+
+		for i, x := range expected {
+			if actual[i] != x {
+				t.Errorf("expected %v got %v", x, actual[i])
+			}
+		}
+	})
 }
 
 func TestMain(t *testing.M) {

--- a/site/content/templates/functions.md
+++ b/site/content/templates/functions.md
@@ -99,7 +99,6 @@ gocog}}} -->
 <tr><td>lastIndexAny</td><td>[https://golang.org/pkg/strings/#LastIndexAny](https://golang.org/pkg/strings/#LastIndexAny)</td></tr>
 <tr><td>makeMap</td><td>[makeMap (see below)](/templates/functions/#makemap)</td></tr>
 <tr><td>makeSlice</td><td>[makeSlice (see below)](/templates/functions/#makeslice)</td></tr>
-<tr><td>makeStringSlice</td><td>[makeStringSlice (see below)](/templates/functions/#makestringslice)</td></tr>
 <tr><td>numbers</td><td>[numbers (see below)](/templates/functions/#numbers)</td></tr>
 <tr><td>pascal</td><td>[https://godoc.org/github.com/codemodus/kace#Pascal](https://godoc.org/github.com/codemodus/kace#Pascal)</td></tr>
 <tr><td>repeat</td><td>[https://golang.org/pkg/strings/#Repeat](https://golang.org/pkg/strings/#Repeat)</td></tr>

--- a/site/content/templates/functions.md
+++ b/site/content/templates/functions.md
@@ -145,13 +145,6 @@ statements, etc.
 makeSlice returns the arguments as a single slice. If all the arguments are
 strings, they are returned as a []string, otherwise they're returned as
 []interface{}.
-## makeStringSlice
-` func makeStringSlice(in []interface{}) ([]string, error) `
-
-makeStringSlice converts a slice of interfaces to a slice of strings. If an
-element of the input slice cannot be asserted to string, it returns an error.
-This is useful for converting arrays of strings returned by plugins, as the plugin
-system unmarshals these as slices of interfaces
 ## numbers
 ` func numbers(start, end int) data.Strings `
 

--- a/site/content/templates/functions.md
+++ b/site/content/templates/functions.md
@@ -99,6 +99,7 @@ gocog}}} -->
 <tr><td>lastIndexAny</td><td>[https://golang.org/pkg/strings/#LastIndexAny](https://golang.org/pkg/strings/#LastIndexAny)</td></tr>
 <tr><td>makeMap</td><td>[makeMap (see below)](/templates/functions/#makemap)</td></tr>
 <tr><td>makeSlice</td><td>[makeSlice (see below)](/templates/functions/#makeslice)</td></tr>
+<tr><td>makeStringSlice</td><td>[makeStringSlice (see below)](/templates/functions/#makestringslice)</td></tr>
 <tr><td>numbers</td><td>[numbers (see below)](/templates/functions/#numbers)</td></tr>
 <tr><td>pascal</td><td>[https://godoc.org/github.com/codemodus/kace#Pascal](https://godoc.org/github.com/codemodus/kace#Pascal)</td></tr>
 <tr><td>repeat</td><td>[https://golang.org/pkg/strings/#Repeat](https://golang.org/pkg/strings/#Repeat)</td></tr>
@@ -144,6 +145,13 @@ statements, etc.
 makeSlice returns the arguments as a single slice. If all the arguments are
 strings, they are returned as a []string, otherwise they're returned as
 []interface{}.
+## makeStringSlice
+` func makeStringSlice(in []interface{}) ([]string, error) `
+
+makeStringSlice converts a slice of interfaces to a slice of strings. If an
+element of the input slice cannot be asserted to string, it returns an error.
+This is useful for converting arrays of strings returned by plugins, as the plugin
+system unmarshals these as slices of interfaces
 ## numbers
 ` func numbers(start, end int) data.Strings `
 


### PR DESCRIPTION
Encountered this need when using Gnorm in a personal project. Plugin output is marshaled as []interface{} by default, which means you can't send something from the Gnorm template data structure into a plugin and then pipe that data to a function like `join`, because `join` only accepts `[]string`s.

I'm not completely married to the function name or docstring, so open to suggestions on how those could be improved. :)

