### PR TITLE
check for public schema before trimming table name

### DIFF
--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -387,8 +387,10 @@ func queryIndexes(log *log.Logger, db *sql.DB, schemaNames []string) ([]indexRes
 		}
 		r.Columns = strings.Split(cs, ",") // array converted to string in query
 
-		// postgres prepends schema onto table name
-		r.TableName = r.TableName[len(r.SchemaName)+1:]
+		// postgres prepends schema onto table name if outside of public schema
+		if r.SchemaName != "public" {
+			r.TableName = r.TableName[len(r.SchemaName)+1:]
+		}
 
 		results = append(results, r)
 	}


### PR DESCRIPTION
resolves #75

In Postgres, calling ::regclass on a table OID will prefix that table
with the schema if the table exists outside of the search path.
Practically speaking, that means any table outside of "public".