### PR TITLE
ensure consistent index ordering

### DIFF
--- a/database/drivers/mysql/parse.go
+++ b/database/drivers/mysql/parse.go
@@ -130,14 +130,8 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 			indexes[s.TableSchema] = schemaIndex
 		}
 
-		tableIndices, ok := schemaIndex[s.TableName]
-		if !ok {
-			tableIndices = make([]*database.Index, 0)
-			schemaIndex[s.TableName] = tableIndices
-		}
-
 		var index *database.Index
-		for _, i := range tableIndices {
+		for _, i := range schemaIndex[s.TableName] {
 			if i.Name == s.IndexName {
 				index = i
 				break
@@ -145,7 +139,7 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 		}
 		if index == nil {
 			index = &database.Index{Name: s.IndexName}
-			schemaIndex[s.TableName] = append(tableIndices, index)
+			schemaIndex[s.TableName] = append(schemaIndex[s.TableName], index)
 		}
 
 		index.Columns = append(index.Columns, column)

--- a/database/drivers/mysql/parse.go
+++ b/database/drivers/mysql/parse.go
@@ -130,14 +130,14 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 			indexes[s.TableSchema] = schemaIndex
 		}
 
-		tableIndex, ok := schemaIndex[s.TableName]
+		tableIndices, ok := schemaIndex[s.TableName]
 		if !ok {
-			tableIndex = make([]*database.Index, 0)
-			schemaIndex[s.TableName] = tableIndex
+			tableIndices = make([]*database.Index, 0)
+			schemaIndex[s.TableName] = tableIndices
 		}
 
 		var index *database.Index
-		for _, i := range tableIndex {
+		for _, i := range tableIndices {
 			if i.Name == s.IndexName {
 				index = i
 				break
@@ -145,7 +145,7 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 		}
 		if index == nil {
 			index = &database.Index{Name: s.IndexName}
-			schemaIndex[s.TableName] = append(tableIndex, index)
+			schemaIndex[s.TableName] = append(tableIndices, index)
 		}
 
 		index.Columns = append(index.Columns, column)

--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -202,14 +202,14 @@ outer:
 			indexes[r.SchemaName] = schemaIndex
 		}
 
-		tableIndex, ok := schemaIndex[r.TableName]
+		tableIndices, ok := schemaIndex[r.TableName]
 		if !ok {
-			tableIndex = make([]*database.Index, 0)
-			schemaIndex[r.TableName] = tableIndex
+			tableIndices = make([]*database.Index, 0)
+			schemaIndex[r.TableName] = tableIndices
 		}
 
 		var index *database.Index
-		for _, i := range tableIndex {
+		for _, i := range tableIndices {
 			if i.Name == r.IndexName {
 				index = i
 				break
@@ -217,7 +217,7 @@ outer:
 		}
 		if index == nil {
 			index = &database.Index{Name: r.IndexName}
-			schemaIndex[r.TableName] = append(tableIndex, index)
+			schemaIndex[r.TableName] = append(tableIndices, index)
 		}
 
 		index.Columns = columns

--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -202,14 +202,8 @@ outer:
 			indexes[r.SchemaName] = schemaIndex
 		}
 
-		tableIndices, ok := schemaIndex[r.TableName]
-		if !ok {
-			tableIndices = make([]*database.Index, 0)
-			schemaIndex[r.TableName] = tableIndices
-		}
-
 		var index *database.Index
-		for _, i := range tableIndices {
+		for _, i := range schemaIndex[r.TableName] {
 			if i.Name == r.IndexName {
 				index = i
 				break
@@ -217,7 +211,7 @@ outer:
 		}
 		if index == nil {
 			index = &database.Index{Name: r.IndexName}
-			schemaIndex[r.TableName] = append(tableIndices, index)
+			schemaIndex[r.TableName] = append(schemaIndex[r.TableName], index)
 		}
 
 		index.Columns = columns


### PR DESCRIPTION
fixes #82

The databases return index data in a consistent order. The previous
process did not respect that through its use of a map as an
intermediate store. By using slices, we now guarantee that the template
will see the indexes in the order the database returned them.