### PR TITLE
surface index uniqueness

### DIFF
--- a/database/drivers/mysql/parse.go
+++ b/database/drivers/mysql/parse.go
@@ -138,7 +138,7 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 			}
 		}
 		if index == nil {
-			index = &database.Index{Name: s.IndexName}
+			index = &database.Index{Name: s.IndexName, IsUnique: s.NonUnique == 0}
 			schemaIndex[s.TableName] = append(schemaIndex[s.TableName], index)
 		}
 

--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -210,7 +210,7 @@ outer:
 			}
 		}
 		if index == nil {
-			index = &database.Index{Name: r.IndexName}
+			index = &database.Index{Name: r.IndexName, IsUnique: r.IsUnique}
 			schemaIndex[r.TableName] = append(schemaIndex[r.TableName], index)
 		}
 
@@ -346,6 +346,7 @@ type indexResult struct {
 	SchemaName string
 	TableName  string
 	IndexName  string
+	IsUnique   bool
 	Columns    []string
 }
 
@@ -355,6 +356,7 @@ func queryIndexes(log *log.Logger, db *sql.DB, schemaNames []string) ([]indexRes
 		n.nspname as schema,
 		i.indrelid::regclass as table,
 		c.relname as name,
+		i.indisunique as is_unique,
 		array_to_string(ARRAY(
 			SELECT pg_get_indexdef(i.indexrelid, k + 1, true)
 			FROM generate_subscripts(i.indkey, 1) as k
@@ -376,16 +378,16 @@ func queryIndexes(log *log.Logger, db *sql.DB, schemaNames []string) ([]indexRes
 
 	query := fmt.Sprintf(q, strings.Join(spots, ", "))
 	rows, err := db.Query(query, vals...)
-	defer rows.Close()
 	if err != nil {
 		return nil, errors.WithMessage(err, "error querying indexes")
 	}
+	defer rows.Close()
 
 	var results []indexResult
 	for rows.Next() {
 		var r indexResult
 		var cs string
-		if err := rows.Scan(&r.SchemaName, &r.TableName, &r.IndexName, &cs); err != nil {
+		if err := rows.Scan(&r.SchemaName, &r.TableName, &r.IndexName, &r.IsUnique, &cs); err != nil {
 			return nil, errors.WithMessage(err, "error scanning index")
 		}
 		r.Columns = strings.Split(cs, ",") // array converted to string in query

--- a/database/info.go
+++ b/database/info.go
@@ -37,8 +37,9 @@ type Table struct {
 
 // Index contains the definition of a database index.
 type Index struct {
-	Name    string    // name of the index in the database
-	Columns []*Column // list of columns in this index
+	Name     string    // name of the index in the database
+	IsUnique bool      // true if the index is unique
+	Columns  []*Column // list of columns in this index
 }
 
 // PrimaryKey contains the definition of a database primary key.
@@ -49,7 +50,7 @@ type PrimaryKey struct {
 	Name       string // the original name of the key constraint in the db
 }
 
-// Foreign Key contains the definition of a database foreign key
+// ForeignKey contains the definition of a database foreign key
 type ForeignKey struct {
 	SchemaName               string // the original name of the schema in the db
 	TableName                string // the original name of the table in the db

--- a/run/convert.go
+++ b/run/convert.go
@@ -112,7 +112,8 @@ func makeData(log *log.Logger, info *database.Info, cfg *Config) (*data.DBData, 
 
 			for _, i := range t.Indexes {
 				index := &data.Index{
-					DBName: i.Name,
+					DBName:   i.Name,
+					IsUnique: i.IsUnique,
 				}
 				for _, c := range i.Columns {
 					index.Columns = append(index.Columns, table.ColumnsByName[c.Name])

--- a/run/data/data.go
+++ b/run/data/data.go
@@ -98,7 +98,7 @@ type Column struct {
 	Orig               interface{}                  `yaml:"-" json:"-"` // the raw database column data
 }
 
-// Foreign Key contains the
+// ForeignKey contains the
 type ForeignKey struct {
 	DBName         string            // the original name of the foreign key constraint in the db
 	Name           string            // the converted name of the foreign key constraint
@@ -109,7 +109,7 @@ type ForeignKey struct {
 	FKColumns      ForeignKeyColumns // all foreign key columns belonging to the foreign key
 }
 
-// Foreign Column contains the definition of a database foreign key at the kcolumn level
+// ForeignKeyColumn contains the definition of a database foreign key at the kcolumn level
 type ForeignKeyColumn struct {
 	DBName          string  // the original name of the foreign key constraint in the db
 	ColumnDBName    string  // the original name of the column in the db
@@ -120,9 +120,10 @@ type ForeignKeyColumn struct {
 
 // Index is the data about a table index.
 type Index struct {
-	Name    string  // the converted name of the index
-	DBName  string  // dbname of the index
-	Columns Columns // columns used in the index
+	Name     string  // the converted name of the index
+	DBName   string  // dbname of the index
+	IsUnique bool    // true if index is unique
+	Columns  Columns // columns used in the index
 }
 
 // Enum represents a type that has a set of allowed values.

--- a/run/preview.go
+++ b/run/preview.go
@@ -30,7 +30,7 @@ Enum: {{.Name}}({{$schema}}.{{.DBName}})
 Table: {{.Name}}({{$schema}}.{{.DBName}})
 {{makeTable .Columns "{{.Name}}|{{.DBName}}|{{.Type}}|{{.DBType}}|{{.IsArray}}|{{.IsPrimaryKey}}|{{.IsFK}}|{{.HasFKRef}}|{{.Length}}|{{.UserDefined}}|{{.Nullable}}|{{.HasDefault}}" "Name" "DBName" "Type" "DBType" "IsArray" "IsPrimaryKey" "IsFK" "HasFKRef" "Length" "UserDefined" "Nullable" "HasDefault" -}}
 Indexes:
-{{makeTable .Indexes "{{.Name}}|{{.DBName}}|{{join .Columns.Names \", \"}}" "Name" "DBName" "Columns"}}
+{{makeTable .Indexes "{{.Name}}|{{.DBName}}|{{.IsUnique}}|{{join .Columns.Names \", \"}}" "Name" "DBName" "IsUnique" "Columns"}}
 {{end -}}
 {{end -}}
 `))

--- a/run/preview_test.go
+++ b/run/preview_test.go
@@ -69,7 +69,8 @@ func (dummyDriver) Parse(log *log.Logger, conn string, schemaNames []string, fil
 					Nullable: true,
 				}},
 				Indexes: []*database.Index{{
-					Name: "col1_pkey",
+					Name:     "col1_pkey",
+					IsUnique: true,
 					Columns: []*database.Column{{
 						Name:         "col1",
 						Type:         "int",
@@ -193,6 +194,7 @@ const expectYaml = `schemas:
     indexes:
     - name: abc col1_pkey
       dbname: col1_pkey
+      isunique: true
       columns:
       - name: abc col1
         dbname: col1
@@ -310,11 +312,11 @@ Table: abc table(schema.table)
 | abc col4 | col4   |          | *string | false   | false        | false | false    |      0 | false       | true     | false      |
 +----------+--------+----------+---------+---------+--------------+-------+----------+--------+-------------+----------+------------+
 Indexes:
-+---------------+-----------+----------+
-|     Name      |  DBName   | Columns  |
-+---------------+-----------+----------+
-| abc col1_pkey | col1_pkey | abc col1 |
-+---------------+-----------+----------+
++---------------+-----------+----------+----------+
+|     Name      |  DBName   | IsUnique | Columns  |
++---------------+-----------+----------+----------+
+| abc col1_pkey | col1_pkey | true     | abc col1 |
++---------------+-----------+----------+----------+
 
 
 Table: abc tb2(schema.tb2)
@@ -325,10 +327,10 @@ Table: abc tb2(schema.tb2)
 | abc col2 | col2   | INTEGER | int    | false   | false        | true  | false    |      0 | false       | false    | false      |
 +----------+--------+---------+--------+---------+--------------+-------+----------+--------+-------------+----------+------------+
 Indexes:
-+------+--------+---------+
-| Name | DBName | Columns |
-+------+--------+---------+
-+------+--------+---------+
++------+--------+----------+---------+
+| Name | DBName | IsUnique | Columns |
++------+--------+----------+---------+
++------+--------+----------+---------+
 
 `
 
@@ -472,6 +474,7 @@ var expectJSON = `
             {
               "Name": "abc col1_pkey",
               "DBName": "col1_pkey",
+              "IsUnique": true,
               "Columns": [
                 {
                   "Name": "abc col1",

--- a/site/content/templates/data.md
+++ b/site/content/templates/data.md
@@ -228,6 +228,7 @@ have the following properties:
 | --- | --- | --- |
 | Name | string | the converted name of the index
 | DBName | string | the name of the index from the database
+| IsUnique | bool | true if the index is unique
 | Columns | [Columns](#columns) | the list of the columns used in the index
 
 ### Indexes


### PR DESCRIPTION
resolves #87

Uniqueness is a basic, but important, bit of information for an index.
This information has been available from the DB but it was never
surfaced.