### PR TITLE
Adds Embedded templates using filepaths or globs. Fixes #60.

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -109,6 +109,14 @@ type Config struct {
 	// The first plugin that is found will be the one used.
 	PluginDirs []string
 
+	// TemplatePaths is a list of file paths that will be parsed as templates and
+	// made available to your Table, Schema, And Enum templates.
+	TemplatePaths []string
+
+	// TemplateGlobs is a list of glob patterns that will be parsed as
+	// templates and made available to your Table, Schema, And Enum templates.
+	TemplateGlobs []string
+
 	// OutputDir is the directory relative to the project root (where the
 	// gnorm.toml file is located) in which all the generated files are written
 	// to.

--- a/cli/sample.go
+++ b/cli/sample.go
@@ -39,6 +39,14 @@ DBType = "postgres"
 # Schemas holds the names of schemas to generate code for.
 Schemas = ["public"]
 
+# TemplatePaths is a list of file paths that will be parsed as templates and
+# made available to your Table, Schema, And Enum templates.
+TemplatePaths = []
+
+# TemplateGlobs is a list of glob patterns that will be parsed as
+# templates and made available to your Table, Schema, And Enum templates.
+TemplateGlobs = []
+
 # PluginDirs a list of paths that will be used for finding plugins.  The list
 # will be traversed in order, looking for a specifically named plugin. The first
 # plugin that is found will be the one used.
@@ -173,4 +181,5 @@ StaticDir = "static"
 # .Params value for all templates.
 [Params]
 mySpecialValue = "some value"`
+
 // [[[end]]]

--- a/site/content/templates/_index.md
+++ b/site/content/templates/_index.md
@@ -26,7 +26,7 @@ format the schema information into code, html, whatever.
 The left hand side determines the filename where those contents will be written.
 
 For example, an entry in TablePaths might looks like this:
-`"{{.Schema}}/tables/{{.Table}}.html" = "table.tpl"
+`"{{.Schema}}/tables/{{.Table}}.html" = "table.tpl"`
 
 This would tell gnorm to use the template at ./table.tpl and output data to
 paths formed by the template on the left.  So, if you ran the "users" table from
@@ -38,3 +38,32 @@ If more than one entry is given, more than one file will be created for each
 item.  Thus you could have an entry to generate a db wrapper for your
 application, one entry to generate a protobuf definition, and one entry to
 generate an HTML docs page.
+
+You can define additional templates for import using TemplatePaths and
+TemplateGlobs in your gnorm.toml file. Any files or patterns defined will be
+made available via their filename in your table, schema, or enum templates.
+Please note that the names of the templates are determined by the filename,
+not the full path. This means that if you import two files with the same name
+but different path, the last file imported will be the template available.
+
+The following examples are equivalent:
+
+TemplatePaths:
+```toml
+# gnorm.toml
+TemplatePaths = ["templates/insert.tpl", "templates/upsert.tpl"]
+```
+
+TemplateGlobs:
+```toml
+# gnorm.toml
+TemplateGlobs = ["templates/*.tpl"]
+```
+
+To use in your table, schema, or enum templates
+```gotemplate
+#table.tpl
+{{ template "insert.tpl" .Table }}
+{{ template "upsert.tpl" .Table }}
+```
+


### PR DESCRIPTION
This update adds TemplatePaths and TemplateGlobs to `gnorm.toml`. Keeping
them separate allows easy parsing using `template.parseFiles` and
`template.parseGlob` respectively. This update does not try to handle
duplicate templates or templates with a name other than their filename.