### PR TITLE
Rename index function to not overlap with built-in

### DIFF
--- a/environ/funcs.go
+++ b/environ/funcs.go
@@ -28,7 +28,7 @@ var FuncMap = map[string]interface{}{
 	"hasPrefix":    strings.HasPrefix,
 	"hasSuffix":    strings.HasPrefix,
 	"inc":          inc,
-	"index":        strings.Index,
+	"strIndex":     strings.Index,
 	"indexAny":     strings.IndexAny,
 	"join":         strings.Join,
 	"kebab":        kace.Kebab,

--- a/site/content/templates/functions.md
+++ b/site/content/templates/functions.md
@@ -90,7 +90,7 @@ gocog}}} -->
 <tr><td>hasPrefix</td><td>[https://golang.org/pkg/strings/#HasPrefix](https://golang.org/pkg/strings/#HasPrefix)</td></tr>
 <tr><td>hasSuffix</td><td>[https://golang.org/pkg/strings/#HasPrefix](https://golang.org/pkg/strings/#HasPrefix)</td></tr>
 <tr><td>inc</td><td>[inc (see below)](/templates/functions/#inc)</td></tr>
-<tr><td>index</td><td>[https://golang.org/pkg/strings/#Index](https://golang.org/pkg/strings/#Index)</td></tr>
+<tr><td>strIndex</td><td>[https://golang.org/pkg/strings/#Index](https://golang.org/pkg/strings/#Index)</td></tr>
 <tr><td>indexAny</td><td>[https://golang.org/pkg/strings/#IndexAny](https://golang.org/pkg/strings/#IndexAny)</td></tr>
 <tr><td>join</td><td>[https://golang.org/pkg/strings/#Join](https://golang.org/pkg/strings/#Join)</td></tr>
 <tr><td>kebab</td><td>[https://godoc.org/github.com/codemodus/kace#Kebab](https://godoc.org/github.com/codemodus/kace#Kebab)</td></tr>


### PR DESCRIPTION
We had an 'index' function in our funcmap that mapped to strings.Index
however, this then makes the template built-in 'index' be unavailable.
This fixes that problem by renaming our function.

*this is a potentially breaking change*