### PR TITLE
Append to correct ForeignKeyRefs slice

### DIFF
--- a/run/convert.go
+++ b/run/convert.go
@@ -237,7 +237,7 @@ func mapForeignTable(fkc data.ForeignKeyColumns, convert nameConverter) error {
 	}
 
 	table.ForeignKeys = append(table.ForeignKeys, fk)
-	refTable.ForeignKeyRefs = append(table.ForeignKeyRefs, fk)
+	refTable.ForeignKeyRefs = append(refTable.ForeignKeyRefs, fk)
 	table.FKByName[fk.DBName] = fk
 	refTable.FKRefsByName[fk.DBName] = fk
 

--- a/run/convert_test.go
+++ b/run/convert_test.go
@@ -118,3 +118,171 @@ func TestMakeData(t *testing.T) {
 		t.Errorf("enum value name expected %q but got %q", expected, got)
 	}
 }
+
+func TestForeignKeyRefs(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{
+		NameConversion: template.Must(template.New("").Funcs(environ.FuncMap).Parse(`{{.}}`)),
+		ConfigData: data.ConfigData{
+			TypeMap: map[string]string{
+				"int": "INTEGER",
+			},
+		},
+	}
+
+	info := &database.Info{
+		Schemas: []*database.Schema{{
+			Name: "public",
+			Tables: []*database.Table{
+				{
+					Name: "tbl_1",
+					Columns: []*database.Column{
+						{
+							Name:         "col_1",
+							Type:         "int",
+							IsForeignKey: true,
+							ForeignKey: &database.ForeignKey{
+								Name:              "fk_1",
+								SchemaName:        "public",
+								TableName:         "tbl_1",
+								ColumnName:        "col_1",
+								ForeignTableName:  "tbl_2",
+								ForeignColumnName: "col_1",
+							},
+						},
+						{
+							Name:         "col_2",
+							Type:         "int",
+							IsForeignKey: true,
+							ForeignKey: &database.ForeignKey{
+								Name:              "fk_1",
+								SchemaName:        "public",
+								TableName:         "tbl_1",
+								ColumnName:        "col_2",
+								ForeignTableName:  "tbl_2",
+								ForeignColumnName: "col_2",
+							},
+						},
+					},
+				},
+				{
+					Name: "tbl_2",
+					Columns: []*database.Column{
+						{
+							Name: "col_1",
+							Type: "int",
+						},
+						{
+							Name: "col_2",
+							Type: "int",
+						},
+						{
+							Name:         "col_3",
+							Type:         "int",
+							IsForeignKey: true,
+							ForeignKey: &database.ForeignKey{
+								Name:              "fk_2",
+								SchemaName:        "public",
+								TableName:         "tbl_2",
+								ColumnName:        "col_3",
+								ForeignTableName:  "tbl_3",
+								ForeignColumnName: "col_1",
+							},
+						},
+					},
+				},
+				{
+					Name: "tbl_3",
+					Columns: []*database.Column{
+						{
+							Name: "col_1",
+							Type: "int",
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	log := log.New(&bytes.Buffer{}, "", 0)
+	data, err := makeData(log, info, c)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+
+	tbl1FKs := data.Schemas[0].TablesByName["tbl_1"].ForeignKeys
+	if l := len(tbl1FKs); l != 1 {
+		t.Fatalf("incorrect number of foreign keys; expected %d, got %d", 1, l)
+	}
+	if name := tbl1FKs[0].Name; name != "fk_1" {
+		t.Fatalf("incorrect foreign key name; expected %s, got %s", "fk_1", name)
+	}
+	if l := len(tbl1FKs[0].FKColumns); l != 2 {
+		t.Fatalf("too many foreign key columns; expected %d, got %d", 2, l)
+	}
+	if name := tbl1FKs[0].RefTable.Name; name != "tbl_2" {
+		t.Fatalf("incorrect foreign key table; expected %s, got %s", "tbl_2", name)
+	}
+	if name := tbl1FKs[0].FKColumns[0].Column.Name; name != "col_1" {
+		t.Fatalf("incorrect foreign key column name; expected %s, got %s", "col_1", name)
+	}
+	if name := tbl1FKs[0].FKColumns[1].Column.Name; name != "col_2" {
+		t.Fatalf("incorrect foreign key column name; expected %s, got %s", "col_2", name)
+	}
+
+	tbl2FKRefs := data.Schemas[0].TablesByName["tbl_2"].ForeignKeyRefs
+	if l := len(tbl2FKRefs); l != 1 {
+		t.Fatalf("incorrect number of foreign key refs; expected %d, got %d", 1, l)
+	}
+	if name := tbl2FKRefs[0].Name; name != "fk_1" {
+		t.Fatalf("incorrect foreign key ref; expected %s, got %s", "fk_1", name)
+	}
+	if name := tbl2FKRefs[0].Table.Name; name != "tbl_1" {
+		t.Fatalf("incorrect foreign key ref table; expected %s, got %s", "tbl_1", name)
+	}
+	if l := len(tbl2FKRefs[0].FKColumns); l != 2 {
+		t.Fatalf("incorrect number of foreign key ref columns; expected %d, got %d", 2, l)
+	}
+	if name := tbl2FKRefs[0].FKColumns[0].Column.Name; name != "col_1" {
+		t.Fatalf("incorrect foreign key ref column; expected %s, got %s", "col_1", name)
+	}
+	if name := tbl2FKRefs[0].FKColumns[1].Column.Name; name != "col_2" {
+		t.Fatalf("incorrect foreign key ref column; expected %s, got %s", "col_2", name)
+	}
+
+	tbl2FKs := data.Schemas[0].TablesByName["tbl_2"].ForeignKeys
+	if l := len(tbl2FKs); l != 1 {
+		t.Fatalf("incorrect number of foreign keys; expected %d, got %d", 1, l)
+	}
+	if name := tbl2FKs[0].Name; name != "fk_2" {
+		t.Fatalf("incorrect foreign key name; expected %s, got %s", "fk_2", name)
+	}
+	if l := len(tbl2FKs[0].FKColumns); l != 1 {
+		t.Fatalf("too many foreign key columns; expected %d, got %d", 1, l)
+	}
+	if name := tbl2FKs[0].RefTable.Name; name != "tbl_3" {
+		t.Fatalf("incorrect foreign key table; expected %s, got %s", "tbl_3", name)
+	}
+	if name := tbl2FKs[0].FKColumns[0].Column.Name; name != "col_3" {
+		t.Fatalf("incorrect foreign key column name; expected %s, got %s", "col_3", name)
+	}
+
+	// See: https://github.com/gnormal/gnorm/issues/123
+	tbl3FKRefs := data.Schemas[0].TablesByName["tbl_3"].ForeignKeyRefs
+	if l := len(tbl3FKRefs); l != 1 {
+		t.Fatalf("incorrect number of foreign keys refs; expected %d, got %d", 1, l)
+	}
+	if name := tbl3FKRefs[0].Name; name != "fk_2" {
+		t.Fatalf("incorrect foreign key ref; expected %s, got %s", "fk_2", name)
+	}
+	if name := tbl3FKRefs[0].Table.Name; name != "tbl_2" {
+		t.Fatalf("incorrect foreign key ref table; expected %s, got %s", "tbl_2", name)
+	}
+	if l := len(tbl3FKRefs[0].FKColumns); l != 1 {
+		t.Fatalf("incorrect number of foreign key ref columns; expected %d, got %d", 1, l)
+	}
+	if name := tbl3FKRefs[0].FKColumns[0].Column.Name; name != "col_3" {
+		t.Fatalf("incorrect foreign key ref column; expected %s, got %s", "col_3", name)
+	}
+}


### PR DESCRIPTION
fixes #123

This commit resolves an issue with ForeignKeysRefs being overwritten in
RefTables by the list of ForeignKeys in the source table.