### PR TITLE
MariaDB support: GENERATION_EXPRESSION is nullable

### DIFF
--- a/database/drivers/mysql/gnorm/columns/columns.go
+++ b/database/drivers/mysql/gnorm/columns/columns.go
@@ -30,7 +30,7 @@ type Row struct {
 	Extra                  string         // EXTRA
 	Privileges             string         // PRIVILEGES
 	ColumnComment          string         // COLUMN_COMMENT
-	GenerationExpression   string         // GENERATION_EXPRESSION
+	GenerationExpression   sql.NullString // GENERATION_EXPRESSION
 }
 
 // Field values for every column in Columns.
@@ -55,7 +55,7 @@ var (
 	ExtraCol                  gnorm.StringField        = "EXTRA"
 	PrivilegesCol             gnorm.StringField        = "PRIVILEGES"
 	ColumnCommentCol          gnorm.StringField        = "COLUMN_COMMENT"
-	GenerationExpressionCol   gnorm.StringField        = "GENERATION_EXPRESSION"
+	GenerationExpressionCol   gnorm.SqlNullStringField = "GENERATION_EXPRESSION"
 )
 
 // Query retrieves rows from 'COLUMNS' as a slice of Row.


### PR DESCRIPTION
MariaDB was designed to be a drop-in replacement for MySQL, so the codebase should be able to support it.
The only discrepancy I've encountered is that ```INFORMATION_SCHEMA.COLUMNS.GENERATION_EXPRESSION``` is ```NULL``` by default in MariaDB.

This PR fixes #114, but haven't checked properly if it breaks anything elsewhere.