### PR TITLE
Add Table.Type to distinguish views from tables (#127)

### DIFF
--- a/database/drivers/mysql/parse.go
+++ b/database/drivers/mysql/parse.go
@@ -47,6 +47,7 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 		}
 		schemas[t.TableSchema] = append(schemas[t.TableSchema], &database.Table{
 			Name:    t.TableName,
+			Type:    t.TableType,
 			Comment: t.TableComment,
 		})
 	}

--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -54,6 +54,7 @@ func parse(log *log.Logger, conn string, schemaNames []string, filterTables func
 
 		schemas[t.TableSchema.String] = append(schemas[t.TableSchema.String], &database.Table{
 			Name: t.TableName.String,
+			Type: t.TableType.String,
 		})
 	}
 

--- a/database/info.go
+++ b/database/info.go
@@ -31,6 +31,7 @@ type EnumValue struct {
 // Table contains the definition of a database table.
 type Table struct {
 	Name    string    // the original name of the table in the DB
+	Type    string    // the table type (e.g. VIEW or BASE TABLE)
 	Comment string    // the comment attached to the table
 	Columns []*Column // ordered list of columns in this table
 	Indexes []*Index  // list of indexes in this table

--- a/run/convert.go
+++ b/run/convert.go
@@ -65,6 +65,7 @@ func makeData(log *log.Logger, info *database.Info, cfg *Config) (*data.DBData, 
 		for _, t := range s.Tables {
 			table := &data.Table{
 				DBName:        t.Name,
+				Type:          t.Type,
 				Comment:       t.Comment,
 				Schema:        sch,
 				ColumnsByName: make(map[string]*data.Column, len(t.Columns)),

--- a/run/data/data.go
+++ b/run/data/data.go
@@ -51,6 +51,7 @@ type Schema struct {
 type Table struct {
 	Name           string                 // the converted name of the table
 	DBName         string                 // the original name of the table in the DB
+	Type           string                 // the table type (e.g. VIEW or BASE TABLE)
 	Comment        string                 // the comment attached to the table
 	Schema         *Schema                `yaml:"-" json:"-"` // the schema this table is in
 	Columns        Columns                // Database columns

--- a/run/preview_test.go
+++ b/run/preview_test.go
@@ -52,6 +52,7 @@ func (dummyDriver) Parse(log *log.Logger, conn string, schemaNames []string, fil
 			Name: "schema",
 			Tables: []*database.Table{{
 				Name:    "table",
+				Type:    "BASE TABLE",
 				Comment: "a table",
 				Columns: []*database.Column{{
 					Name:         "col1",
@@ -83,6 +84,7 @@ func (dummyDriver) Parse(log *log.Logger, conn string, schemaNames []string, fil
 				}},
 			}, {
 				Name: "tb2",
+				Type: "BASE TABLE",
 				Columns: []*database.Column{{
 					Name:         "col1",
 					Type:         "int",
@@ -117,6 +119,7 @@ const expectYaml = `schemas:
   tables:
   - name: abc table
     dbname: table
+    type: BASE TABLE
     comment: a table
     columns:
     - name: abc col1
@@ -242,6 +245,7 @@ const expectYaml = `schemas:
         refcolumndbname: col1
   - name: abc tb2
     dbname: tb2
+    type: BASE TABLE
     comment: ""
     columns:
     - name: abc col1
@@ -398,6 +402,7 @@ var expectJSON = `
         {
           "Name": "abc table",
           "DBName": "table",
+          "Type": "BASE TABLE",
           "Comment": "a table",
           "Columns": [
             {
@@ -558,6 +563,7 @@ var expectJSON = `
         {
           "Name": "abc tb2",
           "DBName": "tb2",
+          "Type": "BASE TABLE",
           "Comment": "",
           "Columns": [
             {


### PR DESCRIPTION
Make the table type (`VIEW` or `BASE TABLE`) available in table templates for Postgres and MySQL. See issue #127. The main use case is limiting the functions generated for VIEWs since they don't receive insert, update, or delete queries.