### PR TITLE
support reading table comments when two tables in different schemas h…

### DIFF
--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -559,7 +559,9 @@ func queryTableComments(log *log.Logger, db *sql.DB, schemaNames []string) ([]ta
 			(
 					SELECT obj_description(c.oid)
 					FROM pg_class c
+					JOIN pg_namespace n ON n.oid = c.relnamespace
 					WHERE c.relname = tabs.table_name
+					AND n.nspname IN (%s)
 			) AS column_comment
 	FROM information_schema.tables tabs
 	WHERE tabs.table_schema IN (%s)`
@@ -571,7 +573,8 @@ func queryTableComments(log *log.Logger, db *sql.DB, schemaNames []string) ([]ta
 		vals[i] = schemaNames[i]
 	}
 
-	query := fmt.Sprintf(q, strings.Join(spots, ", "))
+	spotsStr := strings.Join(spots, ", ")
+	query := fmt.Sprintf(q, spotsStr, spotsStr)
 	rows, err := db.Query(query, vals...)
 	if err != nil {
 		return nil, errors.WithMessage(err, "error querying table comments")

--- a/database/drivers/postgres/parse.go
+++ b/database/drivers/postgres/parse.go
@@ -509,7 +509,9 @@ func queryColumnComments(log *log.Logger, db *sql.DB, schemaNames []string) ([]c
 			(
 					SELECT pg_catalog.col_description(c.oid, cols.ordinal_position::int)
 					FROM pg_catalog.pg_class c
+					JOIN pg_namespace n ON n.oid = c.relnamespace
 					WHERE c.relname = cols.table_name
+					AND n.nspname IN (%s)
 			) AS column_comment
 	FROM information_schema.columns cols
 	WHERE cols.table_schema IN (%s)`
@@ -521,7 +523,8 @@ func queryColumnComments(log *log.Logger, db *sql.DB, schemaNames []string) ([]c
 		vals[i] = schemaNames[i]
 	}
 
-	query := fmt.Sprintf(q, strings.Join(spots, ", "))
+	spotsStr := strings.Join(spots, ", ")
+	query := fmt.Sprintf(q, spotsStr, spotsStr)
 	rows, err := db.Query(query, vals...)
 	if err != nil {
 		return nil, errors.WithMessage(err, "error querying column comments")


### PR DESCRIPTION
When you have two schemas with the same table name in them, you get the following error:

```
Error: error querying table comments: pq: more than one row returned by a subquery used as an expression
```

This change fixes that so that the query only fetches comments for the table that belongs to the schema that's being queried.

There might be other places in gnorm where it makes a similar assumption that table names will be unique across schemas, but for my project this change fixed my error and produces the same output as it did before I added the schema with table name matching the name from the other schema.